### PR TITLE
handle race condition with redis

### DIFF
--- a/lib/LANraragi/Controller/Api/Archive.pm
+++ b/lib/LANraragi/Controller/Api/Archive.pm
@@ -149,13 +149,26 @@ sub create_archive {
                     success     => 0,
                     error       => "Checksum mismatch: expected $expected_checksum, got $actual_checksum."
                 },
-                status => 422
+                status => 417
             );
         }
     }
 
     my $filename        = $upload->filename;
     my $uploadMime      = $upload->headers->content_type;
+
+    # utf downgrade (see LANraragi::Utils::Minion)
+    unless (utf8::downgrade($filename, 1)) {
+        $logger->error("Bullshit! File path \"$filename\" could not be converted back to a byte sequence!");
+        return $self->render(
+            json => {
+                operation   => "upload",
+                success     => 0,
+                error       => "\"$filename\" could not be converted back to a byte sequence!"
+            },
+            status => 422
+        )
+    };
 
     # lock resource
     my $lock            = $redis->setnx( "upload:$filename", 1 );

--- a/tools/Documentation/api-documentation/archive-api.md
+++ b/tools/Documentation/api-documentation/archive-api.md
@@ -507,11 +507,21 @@ SHA1 checksum of the Archive.
 ```
 {% endswagger-response %}
 
-{% swagger-response status="422" description="checksum mismatch" %}
+{% swagger-response status="417" description="checksum mismatch" %}
 ```javascript
 {
   "operation": "upload",
   "error": "Checksum mismatch: expected 92cfceb39d57d914ed8b14d0e37643de0797ae56, got 0286dd552c9bea9a69ecb3759e7b94777635514b",
+  "success": 0
+}
+```
+{% endswagger-response %}
+
+{% swagger-response status="422" description="unprocessable entity" %}
+```javascript
+{
+  "operation": "upload",
+  "error": "Filename \"quirky-symbols～☆.cbz\" could not be converted back to a byte sequence!",
   "success": 0
 }
 ```


### PR DESCRIPTION
add redis lock to handle race condition; however, use of redis will require a UTF downgrade. Not all files are eligible for downgrading, so an exception response is returned.