### PR TITLE
More durable logging implementation on Windows

### DIFF
--- a/lib/LANraragi/Controller/Api/Other.pm
+++ b/lib/LANraragi/Controller/Api/Other.pm
@@ -44,15 +44,24 @@ sub serve_serverinfo {
     );
 }
 
-# Test logging by logging a log
+# Test logging endpoint: takes a JSON array of strings and logs each at info level
 sub test_logging {
-    my $self        = shift;
-    my $logger      = get_logger( "Log Test API ", "lanraragi" );
+    my $self   = shift;
+    my $logger = get_logger( "Log Test API ", "lanraragi" );
 
-    # now log
-    $logger->info("info logging now 1");
-    $logger->info("info logging now 2");
-    $logger->info("info logging now 3");
+    my $payload = $self->req->json;
+    my @messages;
+    if ( ref($payload) eq 'ARRAY' ) {
+        @messages = @{$payload};
+    } elsif ( ref($payload) eq 'HASH' && ref( $payload->{messages} ) eq 'ARRAY' ) {
+        @messages = @{ $payload->{messages} };
+    } else {
+        @messages = ();
+    }
+
+    for my $message (@messages) {
+        $logger->info($message);
+    }
 
     return $self->render(
         json => {

--- a/lib/LANraragi/Controller/Api/Other.pm
+++ b/lib/LANraragi/Controller/Api/Other.pm
@@ -72,6 +72,24 @@ sub test_logging {
     );
 }
 
+# Test append-time rotation: logs the same message 100k times at info level
+sub test_append_logrotate {
+    my $self   = shift;
+    my $logger = get_logger( "Log Test API ", "lanraragi" );
+
+    for ( my $i = 0 ; $i < 100000 ; $i++ ) {
+        $logger->info("append-rotation-test");
+    }
+
+    return $self->render(
+        json => {
+            operation => "test_append_logrotate",
+            success   => 1,
+        },
+        status => 200
+    );
+}
+
 # Basic OPDS catalog
 sub serve_opds_catalog {
     my $self = shift;

--- a/lib/LANraragi/Controller/Api/Other.pm
+++ b/lib/LANraragi/Controller/Api/Other.pm
@@ -6,6 +6,7 @@ use Redis;
 
 use LANraragi::Model::Stats;
 use LANraragi::Model::Opds;
+use LANraragi::Utils::Logging    qw(get_logger);
 use LANraragi::Utils::Generic    qw(render_api_response);
 use LANraragi::Utils::Plugins    qw(get_plugin get_plugins use_plugin);
 
@@ -40,6 +41,25 @@ sub serve_serverinfo {
             total_archives         => $arc_stat,
             cache_last_cleared     => $last_clear
         }
+    );
+}
+
+# Test logging by logging a log
+sub test_logging {
+    my $self        = shift;
+    my $logger      = get_logger( "Log Test API ", "lanraragi" );
+
+    # now log
+    $logger->info("info logging now 1");
+    $logger->info("info logging now 2");
+    $logger->info("info logging now 3");
+
+    return $self->render(
+        json => {
+            operation => "test_logging",
+            success   => 1,
+        },
+        status => 200
     );
 }
 

--- a/lib/LANraragi/Controller/Api/Other.pm
+++ b/lib/LANraragi/Controller/Api/Other.pm
@@ -44,50 +44,24 @@ sub serve_serverinfo {
     );
 }
 
-# Test logging endpoint: takes a JSON array of strings and logs each at info level
-sub test_logging {
-    my $self   = shift;
-    my $logger = get_logger( "Log Test API ", "lanraragi" );
+sub log_messages_test {
 
-    my $payload = $self->req->json;
-    my @messages;
-    if ( ref($payload) eq 'ARRAY' ) {
-        @messages = @{$payload};
-    } elsif ( ref($payload) eq 'HASH' && ref( $payload->{messages} ) eq 'ARRAY' ) {
-        @messages = @{ $payload->{messages} };
-    } else {
-        @messages = ();
-    }
+    my $self        = shift;
+    my $data        = $self->req->json;
+    my $messages    = $data->{messages};
+    my $logger      = get_logger( "LANraragi", "lanraragi" ); # second arg MUST be "lanraragi".
 
-    for my $message (@messages) {
+    foreach my $message ( @$messages ) {
         $logger->info($message);
     }
 
-    return $self->render(
+    $self->render(
         json => {
-            operation => "test_logging",
-            success   => 1,
-        },
-        status => 200
+            operation   => "log_messages_test",
+            success     => 1
+        }
     );
-}
 
-# Test append-time rotation: logs the same message 100k times at info level
-sub test_append_logrotate {
-    my $self   = shift;
-    my $logger = get_logger( "Log Test API ", "lanraragi" );
-
-    for ( my $i = 0 ; $i < 100000 ; $i++ ) {
-        $logger->info("append-rotation-test");
-    }
-
-    return $self->render(
-        json => {
-            operation => "test_append_logrotate",
-            success   => 1,
-        },
-        status => 200
-    );
 }
 
 # Basic OPDS catalog

--- a/lib/LANraragi/Utils/Logging.pm
+++ b/lib/LANraragi/Utils/Logging.pm
@@ -31,18 +31,6 @@ BEGIN {
 
 our %LOGGER_CACHE;
 
-# Get perl file handler via Win32 native file handle of a logfile.
-# https://perldoc.perl.org/Win32API::File#createFile
-# https://perldoc.perl.org/Win32API::File#OsFHandleOpen
-sub _get_win32_fh {
-    my $logfile = shift;
-    my $h = Win32API::File::createFile( $logfile, "rw", "rwd" ) or die "createFile failed for $logfile; win32 says: $^E; errno: $!";
-    local *FH;
-    Win32API::File::OsFHandleOpen( *FH, $h, "a" ) or die "OsFHandleOpen failed for $logfile; $!";
-    binmode *FH, ':encoding(UTF-8)';
-    return *FH;
-}
-
 # Ensure logfile created, and the mojo logger cached and returned, or die trying.
 sub _ensure_logger {
     my $logpath     = $_[0];
@@ -63,7 +51,7 @@ sub _ensure_logger {
         } else {
             # get windows logger and fallback to generic logger
             eval {
-                my $fh = _get_win32_fh( $logpath );
+                my $fh = LANraragi::Utils::RotatingLog::get_win32_fh( $logpath );
                 $log = LANraragi::Utils::RotatingLog->new(
                     level => 'info'
                 );
@@ -126,7 +114,7 @@ sub get_logger {
                     $log->handle($fh);
                 }
             } else {
-                my $fh = _get_win32_fh( $logpath );
+                my $fh = LANraragi::Utils::RotatingLog::get_win32_fh( $logpath );
                 $log->handle($fh);
             }
             1;

--- a/lib/LANraragi/Utils/Logging.pm
+++ b/lib/LANraragi/Utils/Logging.pm
@@ -38,13 +38,13 @@ sub _ensure_logger {
     my $operation   = $_[2];
     my $cache_key   = $_[3];
     my $pgname      = $_[4];
-    my $devmode     = $_[5];
     my $log;
 
     eval {
         $log = LANraragi::Utils::RotatingLog->new(
             path    => $logpath,
             logfile => $logfile,
+            pgname  => $pgname,
             level   => 'info',
         );
         $log->handle;
@@ -92,24 +92,12 @@ sub get_logger {
         $log = $LOGGER_CACHE{$cache_key};
 
         eval {
-            if ( IS_UNIX ) {
-                my $cached_inode    = ( stat( $log->handle ) )[1];
-                my $path_inode      = ( stat($logpath) )[1];
-                if ( !defined $cached_inode || !defined $path_inode || $cached_inode != $path_inode ) {
-                    open( my $fh, '>>', $logpath ) or die "Could not open logfile '$logpath': $!";
-                    $log->handle($fh);
-                }
-            } else {
-                my $fh = LANraragi::Utils::RotatingLog::get_win32_fh( $logpath );
-                $log->handle($fh);
-            }
+            LANraragi::Utils::RotatingLog::refresh_handle($log);
             1;
         };
 
         return $log;
     }
-
-    my $devmode = LANraragi::Model::Config->enable_devmode;
 
     # Logfile lock owners have exclusive ability to create a logfile.
     # Non-owners may only append or wait for logfile availability.
@@ -125,34 +113,15 @@ sub get_logger {
 
         if ( $lock ) {
             eval {
-                say "Rotating logfile $logfile";
-
-                # Based on Logfile::Rotate
-                # Rotate existing logs
-                for ( my $i = 7; $i > 1; $i-- ) {
-                    my $j = $i - 1;
-                    my $next = "$logpath.$i.gz";
-                    my $prev = "$logpath.$j.gz";
-                    if ( -r $prev && -f $prev ) {
-                        rename( $prev, $next ) or die "error: rename failed: ($prev,$next)";
-                    }
-                }
-
-                # Move current logs to tempfile to stop new writes to it
-                my $tmp = "$logpath.rotate";
-                unlink $tmp if -e $tmp;
-                rename( $logpath, $tmp ) or die "error: could not detach $logpath to $tmp: $!";
-
-                # Gzip the detached tempfile
-                my $gz = gzopen( "$logpath.1.gz", "wb" ) or die "error: could not gzopen $logpath.1.gz: $!";
-                open( my $handle, '<', $tmp ) or die "Couldn't open $tmp: $!";
-                my $buffer;
-                $gz->gzwrite($buffer) while read( $handle, $buffer, 4096 ) > 0;
-                $gz->gzclose();
-                close $handle;
-                unlink $tmp or die "error: could not delete $tmp: $!";
-                $log = _ensure_logger( $logpath, $logfile, "rotation" , $cache_key, $pgname, $devmode );
+                LANraragi::Utils::RotatingLog::rotate( $logpath );
+                $log = LANraragi::Utils::RotatingLog->new(
+                    path    => $logpath,
+                    logfile => $logfile,
+                    pgname  => $pgname,
+                    level   => 'info',
+                );
                 $log->info("Rotated log files.");
+                $LOGGER_CACHE{$cache_key} = $log;
                 1;
             };
 
@@ -181,8 +150,14 @@ sub get_logger {
             # This happens during start of app (if no logfile exists).
             say "Creating logfile $logfile.";
             eval {
-                $log = _ensure_logger( $logpath, $logfile, "create", $cache_key, $pgname, $devmode );
+                $log = LANraragi::Utils::RotatingLog->new(
+                    path    => $logpath,
+                    logfile => $logfile,
+                    pgname  => $pgname,
+                    level   => 'info',
+                );
                 $log->info("Created logfile.");
+                $LOGGER_CACHE{$cache_key} = $log;
                 1;
             };
 
@@ -198,7 +173,14 @@ sub get_logger {
                     $tries++;
                 } else {
                     eval {
-                        $log = _ensure_logger( $logpath, $logfile, "wait", $cache_key, $pgname, $devmode );
+                        $log = LANraragi::Utils::RotatingLog->new(
+                            path    => $logpath,
+                            logfile => $logfile,
+                            pgname  => $pgname,
+                            level   => 'info',
+                        );
+                        $log->handle;
+                        $LOGGER_CACHE{$cache_key} = $log;
                         1;
                     };
                     $logfile_create_error   = $@;
@@ -216,7 +198,14 @@ sub get_logger {
 
     } else {
         eval {
-            $log = _ensure_logger( $logpath, $logfile, "default", $cache_key, $pgname, $devmode );
+            $log = LANraragi::Utils::RotatingLog->new(
+                path    => $logpath,
+                logfile => $logfile,
+                pgname  => $pgname,
+                level   => 'info',
+            );
+            $log->handle;
+            $LOGGER_CACHE{$cache_key} = $log;
             1;
         };
 

--- a/lib/LANraragi/Utils/Logging.pm
+++ b/lib/LANraragi/Utils/Logging.pm
@@ -79,9 +79,8 @@ sub get_logger {
     eval {
         $log = LANraragi::Utils::RotatingLog->new(
             path    => $logpath,
-            logfile => $logfile,
-            pgname  => $pgname,
             level   => 'info',
+            logfile => $logfile,
         );
         configure_logger( $log, $pgname );
         $LOGGER_CACHE{$cache_key} = $log;

--- a/lib/LANraragi/Utils/Logging.pm
+++ b/lib/LANraragi/Utils/Logging.pm
@@ -48,14 +48,16 @@ sub _ensure_logger {
     my $logpath     = $_[0];
     my $operation   = $_[1];
     my $cache_key   = $_[2];
+    my $pgname      = $_[3];
+    my $devmode     = $_[4];
     my $log;
 
     eval {
         if ( IS_UNIX ) {
             open( my $fh, '>>', $logpath ) or die "Could not create logfile '$logpath': $!";
             $log = LANraragi::Utils::RotatingLog->new(
-                path  => $logpath,
-                level => 'info'
+                path    => $logpath,
+                level   => 'info',
             );
             $log->handle;
         } else {
@@ -133,6 +135,8 @@ sub get_logger {
         return $log;
     }
 
+    my $devmode = LANraragi::Model::Config->enable_devmode;
+
     # Logfile lock owners have exclusive ability to create a logfile.
     # Non-owners may only append or wait for logfile availability.
     my $lock_name   = "log-rotate:$logfile";
@@ -173,7 +177,7 @@ sub get_logger {
                 $gz->gzclose();
                 close $handle;
                 unlink $tmp or die "error: could not delete $tmp: $!";
-                $log = _ensure_logger( $logpath, "rotation" , $cache_key );
+                $log = _ensure_logger( $logpath, "rotation" , $cache_key, $pgname, $devmode );
                 $log->info("Rotated log files.");
                 1;
             };
@@ -203,7 +207,7 @@ sub get_logger {
             # This happens during start of app (if no logfile exists).
             say "Creating logfile $logfile.";
             eval {
-                $log = _ensure_logger( $logpath, "create", $cache_key );
+                $log = _ensure_logger( $logpath, "create", $cache_key, $pgname, $devmode );
                 $log->info("Created logfile.");
                 1;
             };
@@ -220,7 +224,7 @@ sub get_logger {
                     $tries++;
                 } else {
                     eval {
-                        $log = _ensure_logger( $logpath, "wait", $cache_key );
+                        $log = _ensure_logger( $logpath, "wait", $cache_key, $pgname, $devmode );
                         1;
                     };
                     $logfile_create_error   = $@;
@@ -238,53 +242,13 @@ sub get_logger {
 
     } else {
         eval {
-            $log = _ensure_logger( $logpath, "default", $cache_key );
+            $log = _ensure_logger( $logpath, "default", $cache_key, $pgname, $devmode );
             1;
         };
 
         my $logfile_exist_error = $@;
         die $logfile_exist_error if $logfile_exist_error;
     }
-
-    my $devmode = LANraragi::Model::Config->enable_devmode;
-
-    #Tell logger to store debug logs as well in debug mode
-    if ($devmode) {
-        $log->level('debug');
-    }
-
-    # Step down into trace if we're launched from npm run dev-server-verbose
-    if ( $ENV{LRR_DEVSERVER} ) {
-        $log->level('trace');
-    }
-
-    #Copy logged messages to STDOUT with the matching name
-    $log->on(
-        message => sub {
-            my ( $time, $level, @lines ) = @_;
-
-            #Like with logging to file, debug logs are only printed in debug mode
-            unless ( $devmode == 0 && ( $level eq 'debug' || $level eq 'trace' ) ) {
-                print "[$pgname] [$level] ";
-                say $lines[0];
-            }
-        }
-    );
-
-    $log->format(
-        sub {
-            my ( $time, $level, @lines ) = @_;
-            my $time2 = strftime( "%Y-%m-%d %H:%M:%S", localtime($time) );
-
-            my $logstring = join( "\n", @lines );
-
-            # We'd like to make sure we always show proper UTF-8.
-            # redis_decode, while not initially designed for this, does the job.
-            $logstring = redis_decode($logstring);
-
-            return "[$time2] [$pgname] [$level] $logstring\n";
-        }
-    );
 
     return $log;
 }

--- a/lib/LANraragi/Utils/Logging.pm
+++ b/lib/LANraragi/Utils/Logging.pm
@@ -44,10 +44,9 @@ sub _get_win32_fh {
 
 # Ensure logfile created, and the mojo logger cached and returned, or die trying.
 sub _ensure_logger {
-    my $pgname      = $_[0];
-    my $logpath     = $_[1];
-    my $operation   = $_[2];
-    my $cache_key   = $_[3];
+    my $logpath     = $_[0];
+    my $operation   = $_[1];
+    my $cache_key   = $_[2];
     my $log;
 
     eval {
@@ -173,7 +172,7 @@ sub get_logger {
                 $gz->gzclose();
                 close $handle;
                 unlink $tmp or die "error: could not delete $tmp: $!";
-                $log = _ensure_logger( $pgname, $logpath, "rotation" , $cache_key );
+                $log = _ensure_logger( $logpath, "rotation" , $cache_key );
                 $log->info("Rotated log files.");
                 1;
             };
@@ -203,7 +202,7 @@ sub get_logger {
             # This happens during start of app (if no logfile exists).
             say "Creating logfile $logfile.";
             eval {
-                $log = _ensure_logger( $pgname, $logpath, "create", $cache_key );
+                $log = _ensure_logger( $logpath, "create", $cache_key );
                 $log->info("Created logfile.");
                 1;
             };
@@ -220,7 +219,7 @@ sub get_logger {
                     $tries++;
                 } else {
                     eval {
-                        $log = _ensure_logger( $pgname, $logpath, "wait", $cache_key );
+                        $log = _ensure_logger( $logpath, "wait", $cache_key );
                         1;
                     };
                     $logfile_create_error   = $@;
@@ -238,7 +237,7 @@ sub get_logger {
 
     } else {
         eval {
-            $log = _ensure_logger( $pgname, $logpath, "default", $cache_key );
+            $log = _ensure_logger( $logpath, "default", $cache_key );
             1;
         };
 

--- a/lib/LANraragi/Utils/Logging.pm
+++ b/lib/LANraragi/Utils/Logging.pm
@@ -21,7 +21,9 @@ use constant IS_UNIX => ( $Config{osname} ne 'MSWin32' );
 # Contains all functions related to logging.
 use Exporter 'import';
 our @EXPORT_OK = qw(get_logger get_plugin_logger get_logdir get_lines_from_file);
-our %LOGGER_CACHE;
+
+# TODO: remove the cache until the windows problem is solved.
+# our %LOGGER_CACHE;
 
 BEGIN {
     if ( !IS_UNIX ) {
@@ -53,22 +55,22 @@ sub get_logger {
     my $cache_key   = "$logfile|$pgname";
     my $log;
 
-    # Reuse cached logger if exists
-    if ( exists $LOGGER_CACHE{$cache_key} && -e $logpath && -s $logpath <= 1048576 ) {
-        my $cached          = $LOGGER_CACHE{$cache_key};
+    # # Reuse cached logger if exists
+    # if ( exists $LOGGER_CACHE{$cache_key} && -e $logpath && -s $logpath <= 1048576 ) {
+    #     my $cached          = $LOGGER_CACHE{$cache_key};
 
-        unless ( IS_UNIX ) {
-            return $cached;
-        }
+    #     unless ( IS_UNIX ) {
+    #         return $cached;
+    #     }
 
-        my $cached_inode    = ( stat( $cached->handle ) )[1];
-        my $path_inode      = ( stat($logpath) )[1];
-        if ( !defined $cached_inode || !defined $path_inode || $cached_inode != $path_inode ) {
-            open( my $fh, '>>', $logpath ) or die "Could not open logfile '$logpath': $!";
-            $cached->handle($fh);
-        }
-        return $cached;
-    }
+    #     my $cached_inode    = ( stat( $cached->handle ) )[1];
+    #     my $path_inode      = ( stat($logpath) )[1];
+    #     if ( !defined $cached_inode || !defined $path_inode || $cached_inode != $path_inode ) {
+    #         open( my $fh, '>>', $logpath ) or die "Could not open logfile '$logpath': $!";
+    #         $cached->handle($fh);
+    #     }
+    #     return $cached;
+    # }
 
     # Logfile lock owners have exclusive ability to create a logfile.
     # Non-owners may only append or wait for logfile availability.
@@ -129,7 +131,7 @@ sub get_logger {
                     die "Failed to instantiate Mojo::Log for '$pgname' at '$logpath' (rotation): $e";
                 };
                 $log = $newlog;
-                $LOGGER_CACHE{$cache_key} = $log;
+                # $LOGGER_CACHE{$cache_key} = $log;
             };
 
             $rotation_error = $@;
@@ -175,7 +177,7 @@ sub get_logger {
                     die "Failed to instantiate Mojo::Log for '$pgname' at '$logpath' (wait branch): $@";
                 };
                 $log = $newlog;
-                $LOGGER_CACHE{$cache_key} = $log;
+                # $LOGGER_CACHE{$cache_key} = $log;
             } else {
                 $logfile_create_error = "Timed out waiting for logfile to be created: $logpath"
             }
@@ -199,7 +201,7 @@ sub get_logger {
                     die "Failed to instantiate Mojo::Log for '$pgname' at '$logpath' (create branch): $e";
                 };
                 $log = $newlog;
-                $LOGGER_CACHE{$cache_key} = $log;
+                # $LOGGER_CACHE{$cache_key} = $log;
                 1;
             };
 
@@ -224,7 +226,7 @@ sub get_logger {
             die "Failed to instantiate Mojo::Log for '$pgname' at '$logpath' (default branch): $e";
         };
         $log = $newlog;
-        $LOGGER_CACHE{$cache_key} = $log;
+        # $LOGGER_CACHE{$cache_key} = $log;
     }
 
     my $devmode = LANraragi::Model::Config->enable_devmode;

--- a/lib/LANraragi/Utils/Logging.pm
+++ b/lib/LANraragi/Utils/Logging.pm
@@ -16,12 +16,18 @@ use Compress::Zlib;
 use LANraragi::Model::Config;
 use LANraragi::Utils::Redis qw(redis_decode);
 
+use constant IS_UNIX => ( $Config{osname} ne 'MSWin32' );
+
 # Contains all functions related to logging.
 use Exporter 'import';
 our @EXPORT_OK = qw(get_logger get_plugin_logger get_logdir get_lines_from_file);
-
-use constant IS_UNIX => ( $Config{osname} ne 'MSWin32' );
 our %LOGGER_CACHE;
+
+BEGIN {
+    if ( !IS_UNIX ) {
+        require Win32API::File;
+    }
+}
 
 # Get the Log folder.
 sub get_logdir {

--- a/lib/LANraragi/Utils/Logging.pm
+++ b/lib/LANraragi/Utils/Logging.pm
@@ -22,13 +22,55 @@ use constant IS_UNIX => ( $Config{osname} ne 'MSWin32' );
 use Exporter 'import';
 our @EXPORT_OK = qw(get_logger get_plugin_logger get_logdir get_lines_from_file);
 
-# TODO: remove the cache until the windows problem is solved.
-# our %LOGGER_CACHE;
-
 BEGIN {
     if ( !IS_UNIX ) {
         require Win32API::File;
     }
+}
+
+our %LOGGER_CACHE;
+
+# Get file handler in Windows.
+# https://perldoc.perl.org/Win32API::File#createFile
+sub _get_win32_fh {
+    my $logfile = shift;
+    my $h = Win32API::File::createFile( $logfile, "rw", "rwd" ) or die "createFile failed for $logfile; win32 says: $^E; errno: $!";
+    my $fh = Win32API::File::OsFHandleOpen( $h, "a" ) or die "OsFHandleOpen failed for $logfile; $!";
+    binmode $fh, ':encoding(UTF-8)';
+    return $fh;
+}
+
+# Ensure logfile created, and the mojo logger cached and returned, or die trying.
+sub _ensure_logger {
+    my $pgname      = $_[0];
+    my $logpath     = $_[1];
+    my $operation   = $_[2];
+    my $cache_key   = $_[3];
+    my $log;
+
+    eval {
+        if ( IS_UNIX ) {
+            open( my $fh, '>>', $logpath ) or die "Could not create logfile '$logpath': $!";
+            $log = Mojo::Log->new(
+                path  => $logpath,
+                level => 'info'
+            );
+            $log->handle;
+        } else {
+            my $fh = _get_win32_fh( $logpath );
+            $log = Mojo::Log->new(
+                level => 'info'
+            );
+            $log->handle( $fh );
+        }
+        1;
+    };
+
+    my $error = $@;
+    die $error if $error;
+
+    $LOGGER_CACHE{$cache_key} = $log;
+    return $log;
 }
 
 # Get the Log folder.
@@ -55,22 +97,22 @@ sub get_logger {
     my $cache_key   = "$logfile|$pgname";
     my $log;
 
-    # # Reuse cached logger if exists
-    # if ( exists $LOGGER_CACHE{$cache_key} && -e $logpath && -s $logpath <= 1048576 ) {
-    #     my $cached          = $LOGGER_CACHE{$cache_key};
+    # Reuse cached logger if exists
+    if ( exists $LOGGER_CACHE{$cache_key} && -e $logpath && -s $logpath <= 1048576 ) {
+        my $cached          = $LOGGER_CACHE{$cache_key};
 
-    #     unless ( IS_UNIX ) {
-    #         return $cached;
-    #     }
+        unless ( IS_UNIX ) {
+            return $cached;
+        }
 
-    #     my $cached_inode    = ( stat( $cached->handle ) )[1];
-    #     my $path_inode      = ( stat($logpath) )[1];
-    #     if ( !defined $cached_inode || !defined $path_inode || $cached_inode != $path_inode ) {
-    #         open( my $fh, '>>', $logpath ) or die "Could not open logfile '$logpath': $!";
-    #         $cached->handle($fh);
-    #     }
-    #     return $cached;
-    # }
+        my $cached_inode    = ( stat( $cached->handle ) )[1];
+        my $path_inode      = ( stat($logpath) )[1];
+        if ( !defined $cached_inode || !defined $path_inode || $cached_inode != $path_inode ) {
+            open( my $fh, '>>', $logpath ) or die "Could not open logfile '$logpath': $!";
+            $cached->handle($fh);
+        }
+        return $cached;
+    }
 
     # Logfile lock owners have exclusive ability to create a logfile.
     # Non-owners may only append or wait for logfile availability.
@@ -85,7 +127,6 @@ sub get_logger {
         my $rotation_error;
 
         if ( $lock ) {
-
             eval {
                 say "Rotating logfile $logfile";
 
@@ -112,26 +153,10 @@ sub get_logger {
                 $gz->gzwrite($buffer) while read( $handle, $buffer, 4096 ) > 0;
                 $gz->gzclose();
                 close $handle;
-
                 unlink $tmp or die "error: could not delete $tmp: $!";
-
-                open( my $fh, '>>', $logpath ) or die "Could not create logfile '$logpath': $!";
-                close $fh;
-                my $newlog;
-                eval {
-                    $newlog = Mojo::Log->new(
-                        path  => $logpath,
-                        level => 'info'
-                    );
-                    $newlog->handle;
-                    $newlog->info("Rotated log files.");
-                    1;
-                } or do {
-                    my $e = $@ || 'unknown error';
-                    die "Failed to instantiate Mojo::Log for '$pgname' at '$logpath' (rotation): $e";
-                };
-                $log = $newlog;
-                # $LOGGER_CACHE{$cache_key} = $log;
+                $log = _ensure_logger( $pgname, $logpath, "rotation" , $cache_key );
+                $log->info("Rotated log files.");
+                1;
             };
 
             $rotation_error = $@;
@@ -155,78 +180,51 @@ sub get_logger {
         $lock           = $redis->set( $lock_name, 1, 'NX', 'EX', 10 );
 
         my $logfile_create_error;
-        if ( !$lock ) {
-            # Another worker is rotating/creating the logfile.
-            my $tries = 0;
-            while ( $tries < 100 && !-e $logpath ) {
-                Time::HiRes::sleep(0.1);
-                $tries++;
-            }
-            if ( -e $logpath ) {
-                my $newlog;
-                eval {
-                    $newlog = Mojo::Log->new(
-                        path  => $logpath,
-                        level => 'info'
-                    );
-                    $newlog->handle;
-                    $newlog->info("Created log file.");
-                    1;
-                } or do {
-                    my $e = $@;
-                    die "Failed to instantiate Mojo::Log for '$pgname' at '$logpath' (wait branch): $@";
-                };
-                $log = $newlog;
-                # $LOGGER_CACHE{$cache_key} = $log;
-            } else {
-                $logfile_create_error = "Timed out waiting for logfile to be created: $logpath"
-            }
-        } else {
+        if ( $lock ) {
             # This happens during start of app (if no logfile exists).
+            say "Creating logfile $logfile.";
             eval {
-                say "Creating logfile $logfile.";
-
-                open( my $fh, '>>', $logpath ) or die "Could not create logfile '$logpath': $!";
-                close $fh;
-                my $newlog;
-                eval {
-                    $newlog = Mojo::Log->new(
-                        path  => $logpath,
-                        level => 'info'
-                    );
-                    $newlog->handle;
-                    1;
-                } or do {
-                    my $e = $@ || 'unknown error';
-                    die "Failed to instantiate Mojo::Log for '$pgname' at '$logpath' (create branch): $e";
-                };
-                $log = $newlog;
-                # $LOGGER_CACHE{$cache_key} = $log;
+                $log = _ensure_logger( $pgname, $logpath, "create", $cache_key );
+                $log->info("Created logfile.");
                 1;
             };
 
             $logfile_create_error = $@;
             $redis->del($lock_name);
+        } else {
+            # Another worker is rotating/creating the logfile.
+            my $tries       = 0;
+            my $acquired    = 0;
+            while ( $tries < 100 ) {
+                if ( !-e $logpath ) {
+                    Time::HiRes::sleep(0.1);
+                    $tries++;
+                } else {
+                    eval {
+                        $log = _ensure_logger( $pgname, $logpath, "wait", $cache_key );
+                        1;
+                    };
+                    $logfile_create_error   = $@;
+                    $acquired               = 1;
+                    last;
+                }
+            }
+            if ( !$acquired ) {
+                $logfile_create_error = "Timed out waiting for logfile to be created: $logpath";
+            }
         }
 
         $redis->quit();
         die $logfile_create_error if $logfile_create_error;
 
     } else {
-        my $newlog;
         eval {
-            $newlog = Mojo::Log->new(
-                path  => $logpath,
-                level => 'info'
-            );
-            $newlog->handle;
+            $log = _ensure_logger( $pgname, $logpath, "default", $cache_key );
             1;
-        } or do {
-            my $e = $@ || 'unknown error';
-            die "Failed to instantiate Mojo::Log for '$pgname' at '$logpath' (default branch): $e";
         };
-        $log = $newlog;
-        # $LOGGER_CACHE{$cache_key} = $log;
+
+        my $logfile_exist_error = $@;
+        die $logfile_exist_error if $logfile_exist_error;
     }
 
     my $devmode = LANraragi::Model::Config->enable_devmode;

--- a/lib/LANraragi/Utils/Logging.pm
+++ b/lib/LANraragi/Utils/Logging.pm
@@ -52,23 +52,11 @@ sub _ensure_logger {
     };
 
     if ( my $error = $@ ) {
-        my $msg = "Logger initialization failed during $operation: $error";
-        eval {
-            my $timestamp = strftime( "%Y-%m-%d %H:%M:%S", localtime(time) );
-            my $formatted = "[$timestamp] [$pgname] [error] Fatal error while initializing logger ($operation): $error\n";
-            if ( open my $fh, '>>', $logpath ) {
-                print $fh $formatted;
-                close $fh;
-            } else {
-                warn "Could not write to logfile $logpath: $!";
-            }
-        };
-        die $msg;
-    }
-
-    # Raise an error if log initialization failed (but is still able to emit files).
-    if ( my $init_error = $log->init_error ) {
-        $log->error("Failed to initialize logger: $init_error ");
+        $log = Mojo::Log->new(
+            path    => $logpath,
+            level   => 'info',
+        );
+        $log->error("RotatingLog initialization failed, falling back to Mojo::Log ($operation): $error");
     }
 
     $LOGGER_CACHE{$cache_key} = $log;

--- a/lib/LANraragi/Utils/Logging.pm
+++ b/lib/LANraragi/Utils/Logging.pm
@@ -60,7 +60,7 @@ sub get_logger {
         $log = $LOGGER_CACHE{$cache_key};
 
         eval {
-            LANraragi::Utils::RotatingLog::refresh_handle($log);
+            refresh_handle($log);
             1;
         } or do {
             # handle cannot be refreshed; invalidate cache and serve normal logger
@@ -178,6 +178,24 @@ sub configure_logger {
             return "[$time2] [$pgname] [$level] $logstring\n";
         }
     );
+}
+
+# Refresh a logger's cached handle.
+sub refresh_handle {
+    my $logger = shift;
+
+    if ( IS_UNIX ) {
+        my $path            = $logger->path;
+        my $cached_inode    = ( stat( $logger->handle ) )[1];
+        my $path_inode      = ( stat( $path ) )[1];
+        if ( !defined $cached_inode || !defined $path_inode || $cached_inode != $path_inode ) {
+            open( my $fh, '>>', $path ) or die "Could not open logfile '$path': $!";
+            $logger->handle($fh);
+        }
+    } else {
+        my $fh = get_win32_fh( $logger->path );
+        $logger->handle($fh);
+    }
 }
 
 1;

--- a/lib/LANraragi/Utils/Logging.pm
+++ b/lib/LANraragi/Utils/Logging.pm
@@ -49,16 +49,27 @@ sub _ensure_logger {
         1;
     };
 
-    my $error = $@;
-    die $error if $error;
-
-    $LOGGER_CACHE{$cache_key} = $log;
+    if ( my $error = $@ ) {
+        my $msg = "Logger initialization failed during $operation: $error";
+        eval {
+            my $timestamp = strftime( "%Y-%m-%d %H:%M:%S", localtime(time) );
+            my $formatted = "[$timestamp] [$pgname] [error] Fatal error while initializing logger ($operation): $error\n";
+            if ( open my $fh, '>>', $logpath ) {
+                print $fh $formatted;
+                close $fh;
+            } else {
+                warn "Could not write to logfile $logpath: $!";
+            }
+        };
+        die $msg;
+    }
 
     # Raise an error if log initialization failed (but is still able to emit files).
     if ( my $init_error = $log->init_error ) {
         $log->error("Failed to initialize logger: $init_error ");
     }
 
+    $LOGGER_CACHE{$cache_key} = $log;
     return $log;
 }
 

--- a/lib/LANraragi/Utils/Logging.pm
+++ b/lib/LANraragi/Utils/Logging.pm
@@ -57,11 +57,23 @@ sub _ensure_logger {
             );
             $log->handle;
         } else {
-            my $fh = _get_win32_fh( $logpath );
-            $log = Mojo::Log->new(
-                level => 'info'
-            );
-            $log->handle( $fh );
+            # get windows logger and fallback to generic logger
+            eval {
+                my $fh = _get_win32_fh( $logpath );
+                $log = Mojo::Log->new(
+                    level => 'info'
+                );
+                $log->handle( $fh );
+                1;
+            } or do {
+                my $error = $@;
+                $log = Mojo::Log->new(
+                    path    => $logpath,
+                    level   => 'info'
+                );
+                $log->handle;
+                $log->error("Failed to create logger from win32API handle: $@");
+            };
         }
         1;
     };

--- a/lib/LANraragi/Utils/Logging.pm
+++ b/lib/LANraragi/Utils/Logging.pm
@@ -34,15 +34,17 @@ our %LOGGER_CACHE;
 # Ensure logfile created, and the mojo logger cached and returned, or die trying.
 sub _ensure_logger {
     my $logpath     = $_[0];
-    my $operation   = $_[1];
-    my $cache_key   = $_[2];
-    my $pgname      = $_[3];
-    my $devmode     = $_[4];
+    my $logfile     = $_[1];
+    my $operation   = $_[2];
+    my $cache_key   = $_[3];
+    my $pgname      = $_[4];
+    my $devmode     = $_[5];
     my $log;
 
     eval {
         $log = LANraragi::Utils::RotatingLog->new(
             path    => $logpath,
+            logfile => $logfile,
             level   => 'info',
         );
         $log->handle;
@@ -161,7 +163,7 @@ sub get_logger {
                 $gz->gzclose();
                 close $handle;
                 unlink $tmp or die "error: could not delete $tmp: $!";
-                $log = _ensure_logger( $logpath, "rotation" , $cache_key, $pgname, $devmode );
+                $log = _ensure_logger( $logpath, $logfile, "rotation" , $cache_key, $pgname, $devmode );
                 $log->info("Rotated log files.");
                 1;
             };
@@ -191,7 +193,7 @@ sub get_logger {
             # This happens during start of app (if no logfile exists).
             say "Creating logfile $logfile.";
             eval {
-                $log = _ensure_logger( $logpath, "create", $cache_key, $pgname, $devmode );
+                $log = _ensure_logger( $logpath, $logfile, "create", $cache_key, $pgname, $devmode );
                 $log->info("Created logfile.");
                 1;
             };
@@ -208,7 +210,7 @@ sub get_logger {
                     $tries++;
                 } else {
                     eval {
-                        $log = _ensure_logger( $logpath, "wait", $cache_key, $pgname, $devmode );
+                        $log = _ensure_logger( $logpath, $logfile, "wait", $cache_key, $pgname, $devmode );
                         1;
                     };
                     $logfile_create_error   = $@;
@@ -226,7 +228,7 @@ sub get_logger {
 
     } else {
         eval {
-            $log = _ensure_logger( $logpath, "default", $cache_key, $pgname, $devmode );
+            $log = _ensure_logger( $logpath, $logfile, "default", $cache_key, $pgname, $devmode );
             1;
         };
 

--- a/lib/LANraragi/Utils/Logging.pm
+++ b/lib/LANraragi/Utils/Logging.pm
@@ -41,32 +41,11 @@ sub _ensure_logger {
     my $log;
 
     eval {
-        if ( IS_UNIX ) {
-            open( my $fh, '>>', $logpath ) or die "Could not create logfile '$logpath': $!";
-            $log = LANraragi::Utils::RotatingLog->new(
-                path    => $logpath,
-                level   => 'info',
-            );
-            $log->handle;
-        } else {
-            # get windows logger and fallback to generic logger
-            eval {
-                my $fh = LANraragi::Utils::RotatingLog::get_win32_fh( $logpath );
-                $log = LANraragi::Utils::RotatingLog->new(
-                    level => 'info'
-                );
-                $log->handle( $fh );
-                1;
-            } or do {
-                my $error = $@;
-                $log = LANraragi::Utils::RotatingLog->new(
-                    path    => $logpath,
-                    level   => 'info'
-                );
-                $log->handle;
-                $log->error("Failed to create logger from win32API handle: $@");
-            };
-        }
+        $log = LANraragi::Utils::RotatingLog->new(
+            path    => $logpath,
+            level   => 'info',
+        );
+        $log->handle;
         1;
     };
 
@@ -74,6 +53,12 @@ sub _ensure_logger {
     die $error if $error;
 
     $LOGGER_CACHE{$cache_key} = $log;
+
+    # Raise an error if log initialization failed (but is still able to emit files).
+    if ( my $init_error = $log->init_error ) {
+        $log->error("Failed to initialize logger: $init_error ");
+    }
+
     return $log;
 }
 

--- a/lib/LANraragi/Utils/Logging.pm
+++ b/lib/LANraragi/Utils/Logging.pm
@@ -113,24 +113,24 @@ sub get_logger {
 
     # Reuse cached logger if exists
     if ( exists $LOGGER_CACHE{$cache_key} && -e $logpath && -s $logpath <= 1048576 ) {
-        my $cached          = $LOGGER_CACHE{$cache_key};
+        $log = $LOGGER_CACHE{$cache_key};
 
         eval {
             if ( IS_UNIX ) {
-                my $cached_inode    = ( stat( $cached->handle ) )[1];
+                my $cached_inode    = ( stat( $log->handle ) )[1];
                 my $path_inode      = ( stat($logpath) )[1];
                 if ( !defined $cached_inode || !defined $path_inode || $cached_inode != $path_inode ) {
                     open( my $fh, '>>', $logpath ) or die "Could not open logfile '$logpath': $!";
-                    $cached->handle($fh);
+                    $log->handle($fh);
                 }
             } else {
                 my $fh = _get_win32_fh( $logpath );
-                $cached->handle($fh);
+                $log->handle($fh);
             }
             1;
         };
 
-        return $cached;
+        return $log;
     }
 
     # Logfile lock owners have exclusive ability to create a logfile.

--- a/lib/LANraragi/Utils/Logging.pm
+++ b/lib/LANraragi/Utils/Logging.pm
@@ -113,16 +113,21 @@ sub get_logger {
     if ( exists $LOGGER_CACHE{$cache_key} && -e $logpath && -s $logpath <= 1048576 ) {
         my $cached          = $LOGGER_CACHE{$cache_key};
 
-        unless ( IS_UNIX ) {
-            return $cached;
-        }
-
+        eval {
+            if ( IS_UNIX ) {
         my $cached_inode    = ( stat( $cached->handle ) )[1];
         my $path_inode      = ( stat($logpath) )[1];
         if ( !defined $cached_inode || !defined $path_inode || $cached_inode != $path_inode ) {
             open( my $fh, '>>', $logpath ) or die "Could not open logfile '$logpath': $!";
             $cached->handle($fh);
         }
+            } else {
+                my $fh = _get_win32_fh( $logpath );
+                $cached->handle($fh);
+            }
+            1;
+        };
+
         return $cached;
     }
 

--- a/lib/LANraragi/Utils/Logging.pm
+++ b/lib/LANraragi/Utils/Logging.pm
@@ -56,7 +56,7 @@ sub get_logger {
     my $log;
 
     # Reuse cached logger if exists
-    if ( exists $LOGGER_CACHE{$cache_key} && -e $logpath && -s $logpath <= 1048576 ) {
+    if ( exists $LOGGER_CACHE{$cache_key} && -e $logpath ) {
         $log = $LOGGER_CACHE{$cache_key};
 
         eval {

--- a/lib/LANraragi/Utils/Logging.pm
+++ b/lib/LANraragi/Utils/Logging.pm
@@ -31,38 +31,6 @@ BEGIN {
 
 our %LOGGER_CACHE;
 
-# Ensure logfile created, and the mojo logger cached and returned, or die trying.
-sub _ensure_logger {
-    my $logpath     = $_[0];
-    my $logfile     = $_[1];
-    my $operation   = $_[2];
-    my $cache_key   = $_[3];
-    my $pgname      = $_[4];
-    my $log;
-
-    eval {
-        $log = LANraragi::Utils::RotatingLog->new(
-            path    => $logpath,
-            logfile => $logfile,
-            pgname  => $pgname,
-            level   => 'info',
-        );
-        $log->handle;
-        1;
-    };
-
-    if ( my $error = $@ ) {
-        $log = Mojo::Log->new(
-            path    => $logpath,
-            level   => 'info',
-        );
-        $log->error("RotatingLog initialization failed, falling back to Mojo::Log ($operation): $error");
-    }
-
-    $LOGGER_CACHE{$cache_key} = $log;
-    return $log;
-}
-
 # Get the Log folder.
 sub get_logdir {
 
@@ -94,124 +62,38 @@ sub get_logger {
         eval {
             LANraragi::Utils::RotatingLog::refresh_handle($log);
             1;
+        } or do {
+            # handle cannot be refreshed; invalidate cache and serve normal logger
+            delete $LOGGER_CACHE{$cache_key};
+            $log = Mojo::Log->new(
+                path    => $logpath,
+                level   => 'info'
+            );
+            $log->error("RotatingLog cached handle refresh failed, falling back to Mojo::Log: $@");
         };
 
         return $log;
     }
 
-    # Logfile lock owners have exclusive ability to create a logfile.
-    # Non-owners may only append or wait for logfile availability.
-    my $lock_name   = "log-rotate:$logfile";
-    my $lock;
-
-    if ( -e $logpath && -s $logpath > 1048576 ) {
-
-        # Rotate log if it's > 1MB
-        my $redis       = LANraragi::Model::Config->get_redis_config;
-        $lock           = $redis->set( $lock_name, 1, 'NX', 'EX', 10 );
-        my $rotation_error;
-
-        if ( $lock ) {
-            eval {
-                LANraragi::Utils::RotatingLog::rotate( $logpath );
-                $log = LANraragi::Utils::RotatingLog->new(
-                    path    => $logpath,
-                    logfile => $logfile,
-                    pgname  => $pgname,
-                    level   => 'info',
-                );
-                $log->info("Rotated log files.");
-                $LOGGER_CACHE{$cache_key} = $log;
-                1;
-            };
-
-            $rotation_error = $@;
-            $redis->del($lock_name);
-
-        }
-
-        $redis->quit();
-        die $rotation_error if $rotation_error;
-
-    }
-
-    # handle logpath existence cases.
-    # case 1 (logfile exist):                   no action needed, just get the logfile handle
-    # case 2 (logfile DNE, lock not acquired):  wait 10s logfile to be available
-    # case 3 (logfile DNE, lock acquired):      create new logfile
-    if ( !-e $logpath ) {
-        # handle cases where a logfile doesn't exist.
-
-        my $redis       = LANraragi::Model::Config->get_redis_config;
-        $lock           = $redis->set( $lock_name, 1, 'NX', 'EX', 10 );
-
-        my $logfile_create_error;
-        if ( $lock ) {
-            # This happens during start of app (if no logfile exists).
-            say "Creating logfile $logfile.";
-            eval {
-                $log = LANraragi::Utils::RotatingLog->new(
-                    path    => $logpath,
-                    logfile => $logfile,
-                    pgname  => $pgname,
-                    level   => 'info',
-                );
-                $log->info("Created logfile.");
-                $LOGGER_CACHE{$cache_key} = $log;
-                1;
-            };
-
-            $logfile_create_error = $@;
-            $redis->del($lock_name);
-        } else {
-            # Another worker is rotating/creating the logfile.
-            my $tries       = 0;
-            my $acquired    = 0;
-            while ( $tries < 100 ) {
-                if ( !-e $logpath ) {
-                    Time::HiRes::sleep(0.1);
-                    $tries++;
-                } else {
-                    eval {
-                        $log = LANraragi::Utils::RotatingLog->new(
-                            path    => $logpath,
-                            logfile => $logfile,
-                            pgname  => $pgname,
-                            level   => 'info',
-                        );
-                        $log->handle;
-                        $LOGGER_CACHE{$cache_key} = $log;
-                        1;
-                    };
-                    $logfile_create_error   = $@;
-                    $acquired               = 1;
-                    last;
-                }
-            }
-            if ( !$acquired ) {
-                $logfile_create_error = "Timed out waiting for logfile to be created: $logpath";
-            }
-        }
-
-        $redis->quit();
-        die $logfile_create_error if $logfile_create_error;
-
-    } else {
-        eval {
-            $log = LANraragi::Utils::RotatingLog->new(
-                path    => $logpath,
-                logfile => $logfile,
-                pgname  => $pgname,
-                level   => 'info',
-            );
-            $log->handle;
-            $LOGGER_CACHE{$cache_key} = $log;
-            1;
-        };
-
-        my $logfile_exist_error = $@;
-        die $logfile_exist_error if $logfile_exist_error;
-    }
+    # Create and cache logger
+    eval {
+        $log = LANraragi::Utils::RotatingLog->new(
+            path    => $logpath,
+            logfile => $logfile,
+            pgname  => $pgname,
+            level   => 'info',
+        );
+        configure_logger( $log, $pgname );
+        $LOGGER_CACHE{$cache_key} = $log;
+        1;
+    } or do {
+        $log = Mojo::Log->new(
+            path    => $logpath,
+            level   => 'info'
+        );
+        configure_logger( $log, $pgname );
+        $log->error("RotatingLog initialization failed, falling back to Mojo::Log: $@");
+    };
 
     return $log;
 }
@@ -249,6 +131,53 @@ sub get_lines_from_file {
 
     return "No logs to be found here!";
 
+}
+
+# Provide logger with the required configs and formatting
+sub configure_logger {
+
+    my $logger  = shift;
+    my $pgname  = shift;
+
+    my $devmode = LANraragi::Model::Config->enable_devmode;
+
+    #Tell logger to store debug logs as well in debug mode
+    if ($devmode) {
+        $logger->level('debug');
+    }
+
+    # Step down into trace if we're launched from npm run dev-server-verbose
+    if ( $ENV{LRR_DEVSERVER} ) {
+        $logger->level('trace');
+    }
+
+    # Copy logged messages to STDOUT with the matching name
+    $logger->on(
+        message => sub {
+            my ( $log, $level, @lines ) = @_;
+
+            # Like with logging to file, debug logs are only printed in debug mode
+            unless ( $devmode == 0 && ( $level eq 'debug' || $level eq 'trace' ) ) {
+                print "[$pgname] [$level] ";
+                say $lines[0];
+            }
+        }
+    );
+
+    $logger->format(
+        sub {
+            my ( $time, $level, @lines ) = @_;
+            my $time2 = strftime( "%Y-%m-%d %H:%M:%S", localtime($time) );
+
+            my $logstring = join( "\n", @lines );
+
+            # We'd like to make sure we always show proper UTF-8.
+            # redis_decode, while not initially designed for this, does the job.
+            $logstring = redis_decode($logstring);
+
+            return "[$time2] [$pgname] [$level] $logstring\n";
+        }
+    );
 }
 
 1;

--- a/lib/LANraragi/Utils/Logging.pm
+++ b/lib/LANraragi/Utils/Logging.pm
@@ -53,7 +53,7 @@ sub _ensure_logger {
     eval {
         if ( IS_UNIX ) {
             open( my $fh, '>>', $logpath ) or die "Could not create logfile '$logpath': $!";
-            $log = Mojo::Log->new(
+            $log = LANraragi::Utils::RotatingLog->new(
                 path  => $logpath,
                 level => 'info'
             );
@@ -62,14 +62,14 @@ sub _ensure_logger {
             # get windows logger and fallback to generic logger
             eval {
                 my $fh = _get_win32_fh( $logpath );
-                $log = Mojo::Log->new(
+                $log = LANraragi::Utils::RotatingLog->new(
                     level => 'info'
                 );
                 $log->handle( $fh );
                 1;
             } or do {
                 my $error = $@;
-                $log = Mojo::Log->new(
+                $log = LANraragi::Utils::RotatingLog->new(
                     path    => $logpath,
                     level   => 'info'
                 );

--- a/lib/LANraragi/Utils/Logging.pm
+++ b/lib/LANraragi/Utils/Logging.pm
@@ -30,14 +30,16 @@ BEGIN {
 
 our %LOGGER_CACHE;
 
-# Get file handler in Windows.
+# Get perl file handler via Win32 native file handle of a logfile.
 # https://perldoc.perl.org/Win32API::File#createFile
+# https://perldoc.perl.org/Win32API::File#OsFHandleOpen
 sub _get_win32_fh {
     my $logfile = shift;
     my $h = Win32API::File::createFile( $logfile, "rw", "rwd" ) or die "createFile failed for $logfile; win32 says: $^E; errno: $!";
-    my $fh = Win32API::File::OsFHandleOpen( $h, "a" ) or die "OsFHandleOpen failed for $logfile; $!";
-    binmode $fh, ':encoding(UTF-8)';
-    return $fh;
+    local *FH;
+    Win32API::File::OsFHandleOpen( *FH, $h, "a" ) or die "OsFHandleOpen failed for $logfile; $!";
+    binmode *FH, ':encoding(UTF-8)';
+    return *FH;
 }
 
 # Ensure logfile created, and the mojo logger cached and returned, or die trying.
@@ -115,12 +117,12 @@ sub get_logger {
 
         eval {
             if ( IS_UNIX ) {
-        my $cached_inode    = ( stat( $cached->handle ) )[1];
-        my $path_inode      = ( stat($logpath) )[1];
-        if ( !defined $cached_inode || !defined $path_inode || $cached_inode != $path_inode ) {
-            open( my $fh, '>>', $logpath ) or die "Could not open logfile '$logpath': $!";
-            $cached->handle($fh);
-        }
+                my $cached_inode    = ( stat( $cached->handle ) )[1];
+                my $path_inode      = ( stat($logpath) )[1];
+                if ( !defined $cached_inode || !defined $path_inode || $cached_inode != $path_inode ) {
+                    open( my $fh, '>>', $logpath ) or die "Could not open logfile '$logpath': $!";
+                    $cached->handle($fh);
+                }
             } else {
                 my $fh = _get_win32_fh( $logpath );
                 $cached->handle($fh);

--- a/lib/LANraragi/Utils/Logging.pm
+++ b/lib/LANraragi/Utils/Logging.pm
@@ -14,6 +14,7 @@ use Encode;
 use File::ReadBackwards;
 use Compress::Zlib;
 use LANraragi::Model::Config;
+use LANraragi::Utils::RotatingLog;
 use LANraragi::Utils::Redis qw(redis_decode);
 
 use constant IS_UNIX => ( $Config{osname} ne 'MSWin32' );

--- a/lib/LANraragi/Utils/RotatingLog.pm
+++ b/lib/LANraragi/Utils/RotatingLog.pm
@@ -29,7 +29,6 @@ BEGIN {
 has 'pgname';
 has 'logfile';
 
-has devmode             => sub { LANraragi::Model::Config->enable_devmode };
 has maxrotationsize     => sub { 1048576 }; # 1 MiB
 has counter             => sub { 0 };
 
@@ -92,47 +91,94 @@ sub new {
     my $self = shift->SUPER::new(@_);
 
     my $pgname  = $self->pgname;
-    my $devmode = $self->devmode;
     my $path    = $self->path;
     my $logfile = $self->logfile;
 
-    #Tell logger to store debug logs as well in debug mode
-    if ($devmode) {
-        $self->level('debug');
+    # Logfile lock owners have exclusive ability to create a logfile.
+    # Non-owners may only append or wait for logfile availability.
+    my $lock_name   = "log-rotate:$logfile";
+    my $lock;
+
+    if ( -e $path && -s $path > 1048576 ) {
+
+        # Rotate log if it's > 1MB
+        my $redis       = LANraragi::Model::Config->get_redis_config;
+        $lock           = $redis->set( $lock_name, 1, 'NX', 'EX', 10 );
+        my $rotation_error;
+
+        if ( $lock ) {
+            eval {
+                LANraragi::Utils::RotatingLog::rotate( $path );
+                $self->info("Rotated log files.");
+                1;
+            };
+
+            $rotation_error = $@;
+            $redis->del($lock_name);
+
+        }
+
+        $redis->quit();
+        die $rotation_error if $rotation_error;
+
     }
 
-    # Step down into trace if we're launched from npm run dev-server-verbose
-    if ( $ENV{LRR_DEVSERVER} ) {
-        $self->level('trace');
-    }
+    # handle logpath existence cases.
+    # case 1 (logfile exist):                   no action needed, just get the logfile handle
+    # case 2 (logfile DNE, lock not acquired):  wait 10s logfile to be available
+    # case 3 (logfile DNE, lock acquired):      create new logfile
+    if ( !-e $path ) {
+        # handle cases where a logfile doesn't exist.
 
-    # Copy logged messages to STDOUT with the matching name
-    $self->on(
-        message => sub {
-            my ( $log, $level, @lines ) = @_;
+        my $redis       = LANraragi::Model::Config->get_redis_config;
+        $lock           = $redis->set( $lock_name, 1, 'NX', 'EX', 10 );
 
-            # Like with logging to file, debug logs are only printed in debug mode
-            unless ( $devmode == 0 && ( $level eq 'debug' || $level eq 'trace' ) ) {
-                print "[$pgname] [$level] ";
-                say $lines[0];
+        my $logfile_create_error;
+        if ( $lock ) {
+            # This happens during start of app (if no logfile exists).
+            say "Creating logfile $logfile.";
+            eval {
+                $self->info("Created logfile.");
+                1;
+            };
+
+            $logfile_create_error = $@;
+            $redis->del($lock_name);
+        } else {
+            # Another worker is rotating/creating the logfile.
+            my $tries       = 0;
+            my $acquired    = 0;
+            while ( $tries < 100 ) {
+                if ( !-e $path ) {
+                    Time::HiRes::sleep(0.1);
+                    $tries++;
+                } else {
+                    eval {
+                        $self->handle;
+                        1;
+                    };
+                    $logfile_create_error   = $@;
+                    $acquired               = 1;
+                    last;
+                }
+            }
+            if ( !$acquired ) {
+                $logfile_create_error = "Timed out waiting for logfile to be created: $path";
             }
         }
-    );
 
-    $self->format(
-        sub {
-            my ( $time, $level, @lines ) = @_;
-            my $time2 = strftime( "%Y-%m-%d %H:%M:%S", localtime($time) );
+        $redis->quit();
+        die $logfile_create_error if $logfile_create_error;
 
-            my $logstring = join( "\n", @lines );
+    } else {
+        eval {
+            $self->handle;
+            1;
+        };
 
-            # We'd like to make sure we always show proper UTF-8.
-            # redis_decode, while not initially designed for this, does the job.
-            $logstring = redis_decode($logstring);
-
-            return "[$time2] [$pgname] [$level] $logstring\n";
-        }
-    );
+        my $logfile_exist_error = $@;
+        die $logfile_exist_error if $logfile_exist_error;
+    }
 
     return $self;
 }

--- a/lib/LANraragi/Utils/RotatingLog.pm
+++ b/lib/LANraragi/Utils/RotatingLog.pm
@@ -21,4 +21,57 @@ BEGIN {
     }
 }
 
+has 'pgname';
+has 'devmode';
+has maxrotationsize => sub { 1048576 }; # 1 MiB
+
+# override: https://docs.mojolicious.org/Mojo/Log#new
+sub new {
+    my $self = shift->SUPER::new(@_);
+
+    my $pgname  = $self->pgname // 'LANraragi';
+    my $devmode = $self->devmode ? 1 : 0;
+    my $path    = $self->path;
+
+    #Tell logger to store debug logs as well in debug mode
+    if ($devmode) {
+        $self->level('debug');
+    }
+
+    # Step down into trace if we're launched from npm run dev-server-verbose
+    if ( $ENV{LRR_DEVSERVER} ) {
+        $self->level('trace');
+    }
+
+    # Copy logged messages to STDOUT with the matching name
+    $self->on(
+        message => sub {
+            my ( $log, $level, @lines ) = @_;
+
+            # Like with logging to file, debug logs are only printed in debug mode
+            unless ( $devmode == 0 && ( $level eq 'debug' || $level eq 'trace' ) ) {
+                print "[$pgname] [$level] ";
+                say $lines[0];
+            }
+        }
+    );
+
+    $self->format(
+        sub {
+            my ( $time, $level, @lines ) = @_;
+            my $time2 = strftime( "%Y-%m-%d %H:%M:%S", localtime($time) );
+
+            my $logstring = join( "\n", @lines );
+
+            # We'd like to make sure we always show proper UTF-8.
+            # redis_decode, while not initially designed for this, does the job.
+            $logstring = redis_decode($logstring);
+
+            return "[$time2] [$pgname] [$level] $logstring\n";
+        }
+    );
+
+    return $self;
+}
+
 1;

--- a/lib/LANraragi/Utils/RotatingLog.pm
+++ b/lib/LANraragi/Utils/RotatingLog.pm
@@ -15,6 +15,9 @@ use Mojo::File;
 use LANraragi::Utils::Redis qw(redis_decode);
 use LANraragi::Model::Config;
 
+use Exporter 'import';
+our @EXPORT_OK = qw(get_win32_fh);
+
 use constant IS_UNIX => ( $Config{osname} ne 'MSWin32' );
 
 BEGIN {
@@ -93,6 +96,18 @@ sub new {
     );
 
     return $self;
+}
+
+# Get perl file handler via Win32 native file handle of a logfile.
+# https://perldoc.perl.org/Win32API::File#createFile
+# https://perldoc.perl.org/Win32API::File#OsFHandleOpen
+sub get_win32_fh {
+    my $logfile = shift;
+    my $h = Win32API::File::createFile( $logfile, "rw", "rwd" ) or die "createFile failed for $logfile; win32 says: $^E; errno: $!";
+    local *FH;
+    Win32API::File::OsFHandleOpen( *FH, $h, "a" ) or die "OsFHandleOpen failed for $logfile; $!";
+    binmode *FH, ':encoding(UTF-8)';
+    return *FH;
 }
 
 1;

--- a/lib/LANraragi/Utils/RotatingLog.pm
+++ b/lib/LANraragi/Utils/RotatingLog.pm
@@ -152,13 +152,14 @@ sub rotate {
 
     # Rotate log if it's > 1MB
     my $redis       = LANraragi::Model::Config->get_redis_config;
-    my $lock           = $redis->set( $lock_name, 1, 'NX', 'EX', 10 );
+    my $lock        = $redis->set( $lock_name, 1, 'NX', 'EX', 10 );
     my $rotation_error;
 
     if ( $lock ) {
         my $logpath = $self->path;
+        my $logfile = $self->logfile;
         eval {
-            say "Rotating logpath $logpath";
+            say "Rotating logfile $logfile";
 
             # Based on Logfile::Rotate
             # Rotate existing logs
@@ -185,8 +186,8 @@ sub rotate {
             close $handle;
             unlink $tmp or die "error: could not delete $tmp: $!";
 
-            # Invalidate the handler.
-            $self->handle(undef);
+            # Refresh the handler.
+            delete $self->{handle};
             $self->info("Rotated log files.");
             1;
         };

--- a/lib/LANraragi/Utils/RotatingLog.pm
+++ b/lib/LANraragi/Utils/RotatingLog.pm
@@ -28,7 +28,8 @@ BEGIN {
 
 has 'logfile';
 
-has maxrotationsize     => sub { 1048576 }; # 1 MiB
+has retention_count     => sub { 0 + ($ENV{LRR_LOGROTATE_FILES} // 7) };        # max number of archived logfiles to retain for log rotation (defaults to 7 files).
+has max_rotation_size   => sub { 0 + ($ENV{LRR_LOGROTATE_SIZE} // 1048576) };   # max size of logfile (in bytes) before triggering rotation on next scan (defaults to 1 MB).
 has counter             => sub { 0 };
 
 # override: https://docs.mojolicious.org/Mojo/Log#handle
@@ -50,7 +51,7 @@ has handle => sub {
 };
 
 # override: https://docs.mojolicious.org/Mojo/Log#append
-# include logic which checks every 1k lines whether to rotate logs.
+# Includes logic which checks every 1k lines whether to rotate logs.
 sub append {
     my ($self, $msg) = @_;
 
@@ -60,7 +61,7 @@ sub append {
     if ( $self->counter % 1000 == 0 ) {
 
         my $path = $self->path;
-        if ( -s $path > $self->maxrotationsize && (my $logfile = $self->logfile) ) {
+        if ( -s $path > $self->max_rotation_size && (my $logfile = $self->logfile) ) {
             my $lock_name   = "log-rotate:$logfile";
             my $redis       = LANraragi::Model::Config->get_redis_config;
             my $lock        = $redis->set( $lock_name, 1, 'NX', 'EX', 10 );
@@ -68,7 +69,7 @@ sub append {
 
             if ( $lock ) {
                 eval {
-                    rotate( $path );
+                    rotate( $path, $self->retention_count );
                     delete $self->{handle};
                     $self->handle;
                 };
@@ -86,6 +87,8 @@ sub append {
 }
 
 # override: https://docs.mojolicious.org/Mojo/Log#new
+# Inherits Mojo::Log to provide log rotation during `new` and `append`, as well as eager handle loading.
+# Complete data logging is not guaranteed: ~0.05-0.1% of logs may be lost during rotation.
 sub new {
     my $self = shift->SUPER::new(@_);
 
@@ -97,7 +100,7 @@ sub new {
     my $lock_name   = "log-rotate:$logfile";
     my $lock;
 
-    if ( -e $path && -s $path > 1048576 ) {
+    if ( -e $path && -s $path > $self->max_rotation_size ) {
 
         # Rotate log if it's > 1MB
         my $redis       = LANraragi::Model::Config->get_redis_config;
@@ -106,7 +109,7 @@ sub new {
 
         if ( $lock ) {
             eval {
-                LANraragi::Utils::RotatingLog::rotate( $path );
+                rotate( $path, $self->retention_count );
                 $self->handle;
                 1;
             };
@@ -207,13 +210,14 @@ sub get_win32_fh {
 
 # Do log rotation.
 sub rotate {
-    my $logpath = shift;
+    my $logpath         = shift;
+    my $retention_count = shift;
 
     say "Rotating logpath $logpath";
 
     # Based on Logfile::Rotate
     # Rotate existing logs
-    for ( my $i = 7; $i > 1; $i-- ) {
+    for ( my $i = $retention_count; $i > 1; $i-- ) {
         my $j = $i - 1;
         my $next = "$logpath.$i.gz";
         my $prev = "$logpath.$j.gz";

--- a/lib/LANraragi/Utils/RotatingLog.pm
+++ b/lib/LANraragi/Utils/RotatingLog.pm
@@ -239,22 +239,4 @@ sub rotate {
     unlink $tmp or die "error: could not delete $tmp: $!";
 }
 
-# Refreshed cached handle.
-sub refresh_handle {
-    my $self = shift;
-
-    if ( IS_UNIX ) {
-        my $path            = $self->path;
-        my $cached_inode    = ( stat( $self->handle ) )[1];
-        my $path_inode      = ( stat( $path ) )[1];
-        if ( !defined $cached_inode || !defined $path_inode || $cached_inode != $path_inode ) {
-            open( my $fh, '>>', $path ) or die "Could not open logfile '$path': $!";
-            $self->handle($fh);
-        }
-    } else {
-        my $fh = get_win32_fh( $self->path );
-        $self->handle($fh);
-    }
-}
-
 1;

--- a/lib/LANraragi/Utils/RotatingLog.pm
+++ b/lib/LANraragi/Utils/RotatingLog.pm
@@ -27,9 +27,10 @@ BEGIN {
 }
 
 has 'pgname';
-has 'devmode';
+has 'logfile';
 has 'init_error';       # initialization error
 
+has devmode             => sub { LANraragi::Model::Config->enable_devmode };
 has maxrotationsize     => sub { 1048576 }; # 1 MiB
 has counter             => sub { 0 };
 
@@ -67,8 +68,9 @@ sub append {
     # every 1k lines, check size of path for log rotation
     if ( $self->counter % 1000 == 0 ) {
         return unless my $path = $self->path;
-        if ( -s $path > $self->maxrotationsize ) {
-            # TODO: do log rotation.
+        if ( -s $path > $self->maxrotationsize && (my $logfile = $self->logfile) ) {
+            my $lock_name = "log-rotate:$logfile";
+            rotate( $self, $lock_name, "rotation" );
         }
     }
 
@@ -80,8 +82,9 @@ sub new {
     my $self = shift->SUPER::new(@_);
 
     my $pgname  = $self->pgname // 'LANraragi';
-    my $devmode = $self->devmode ? 1 : 0;
+    my $devmode = $self->devmode;
     my $path    = $self->path;
+    my $logfile = $self->logfile;
 
     #Tell logger to store debug logs as well in debug mode
     if ($devmode) {
@@ -134,6 +137,63 @@ sub get_win32_fh {
     Win32API::File::OsFHandleOpen( *FH, $h, "a" ) or die "OsFHandleOpen failed for $logfile; $!";
     binmode *FH, ':encoding(UTF-8)';
     return *FH;
+}
+
+# Do log rotation.
+sub rotate {
+    my $self        = shift;
+    my $lock_name   = shift;
+    my $operation   = shift;
+
+    # Rotate log if it's > 1MB
+    my $redis       = LANraragi::Model::Config->get_redis_config;
+    my $lock           = $redis->set( $lock_name, 1, 'NX', 'EX', 10 );
+    my $rotation_error;
+
+    if ( $lock ) {
+        my $logpath = $self->path;
+        eval {
+            say "Rotating logpath $logpath";
+
+            # Based on Logfile::Rotate
+            # Rotate existing logs
+            for ( my $i = 7; $i > 1; $i-- ) {
+                my $j = $i - 1;
+                my $next = "$logpath.$i.gz";
+                my $prev = "$logpath.$j.gz";
+                if ( -r $prev && -f $prev ) {
+                    rename( $prev, $next ) or die "error: rename failed: ($prev,$next)";
+                }
+            }
+
+            # Move current logs to tempfile to stop new writes to it
+            my $tmp = "$logpath.rotate";
+            unlink $tmp if -e $tmp;
+            rename( $logpath, $tmp ) or die "error: could not detach $logpath to $tmp: $!";
+
+            # Gzip the detached tempfile
+            my $gz = gzopen( "$logpath.1.gz", "wb" ) or die "error: could not gzopen $logpath.1.gz: $!";
+            open( my $handle, '<', $tmp ) or die "Couldn't open $tmp: $!";
+            my $buffer;
+            $gz->gzwrite($buffer) while read( $handle, $buffer, 4096 ) > 0;
+            $gz->gzclose();
+            close $handle;
+            unlink $tmp or die "error: could not delete $tmp: $!";
+
+            # Invalidate the handler.
+            $self->handle(undef);
+            $self->info("Rotated log files.");
+            1;
+        };
+
+        $rotation_error = $@;
+        $redis->del($lock_name);
+
+    }
+
+    $redis->quit();
+    die $rotation_error if $rotation_error;
+
 }
 
 1;

--- a/lib/LANraragi/Utils/RotatingLog.pm
+++ b/lib/LANraragi/Utils/RotatingLog.pm
@@ -28,7 +28,6 @@ BEGIN {
 
 has 'pgname';
 has 'logfile';
-has 'init_error';       # initialization error
 
 has devmode             => sub { LANraragi::Model::Config->enable_devmode };
 has maxrotationsize     => sub { 1048576 }; # 1 MiB
@@ -43,14 +42,8 @@ has handle => sub {
 
     # File
     if ( !IS_UNIX ) {
-        my $fh = eval {
-            get_win32_fh($path)
-        };
-        if ( my $error = $@ ) {
-            $self->init_error($error);
-        } else {
-            return $fh if $fh;
-        }
+        my $fh = get_win32_fh($path);
+        return $fh if $fh;
     }
 
     # Fallback with default handle.

--- a/lib/LANraragi/Utils/RotatingLog.pm
+++ b/lib/LANraragi/Utils/RotatingLog.pm
@@ -60,11 +60,28 @@ sub append {
 
     # every 1k lines, check size of path for log rotation
     if ( $self->counter % 1000 == 0 ) {
-        return unless my $path = $self->path;
+
+        my $path = $self->path;
         if ( -s $path > $self->maxrotationsize && (my $logfile = $self->logfile) ) {
-            my $lock_name = "log-rotate:$logfile";
-            rotate( $self, $lock_name, "rotation" );
+            my $lock_name   = "log-rotate:$logfile";
+            my $redis       = LANraragi::Model::Config->get_redis_config;
+            my $lock        = $redis->set( $lock_name, 1, 'NX', 'EX', 10 );
+            my $rotation_error;
+
+            if ( $lock ) {
+                eval {
+                    rotate( $path );
+                    delete $self->{handle};
+                    $self->info("Rotated log files.");
+                };
+                $rotation_error = $@;
+                $redis->del($lock_name);
+            }
+
+            $redis->quit();
+            die $rotation_error if $rotation_error;
         }
+
     }
 
     return $self->SUPER::append($msg);
@@ -146,60 +163,34 @@ sub get_win32_fh {
 
 # Do log rotation.
 sub rotate {
-    my $self        = shift;
-    my $lock_name   = shift;
-    my $operation   = shift;
+    my $logpath = shift;
 
-    # Rotate log if it's > 1MB
-    my $redis       = LANraragi::Model::Config->get_redis_config;
-    my $lock        = $redis->set( $lock_name, 1, 'NX', 'EX', 10 );
-    my $rotation_error;
+    say "Rotating logpath $logpath";
 
-    if ( $lock ) {
-        my $logpath = $self->path;
-        my $logfile = $self->logfile;
-        eval {
-            say "Rotating logfile $logfile";
-
-            # Based on Logfile::Rotate
-            # Rotate existing logs
-            for ( my $i = 7; $i > 1; $i-- ) {
-                my $j = $i - 1;
-                my $next = "$logpath.$i.gz";
-                my $prev = "$logpath.$j.gz";
-                if ( -r $prev && -f $prev ) {
-                    rename( $prev, $next ) or die "error: rename failed: ($prev,$next)";
-                }
-            }
-
-            # Move current logs to tempfile to stop new writes to it
-            my $tmp = "$logpath.rotate";
-            unlink $tmp if -e $tmp;
-            rename( $logpath, $tmp ) or die "error: could not detach $logpath to $tmp: $!";
-
-            # Gzip the detached tempfile
-            my $gz = gzopen( "$logpath.1.gz", "wb" ) or die "error: could not gzopen $logpath.1.gz: $!";
-            open( my $handle, '<', $tmp ) or die "Couldn't open $tmp: $!";
-            my $buffer;
-            $gz->gzwrite($buffer) while read( $handle, $buffer, 4096 ) > 0;
-            $gz->gzclose();
-            close $handle;
-            unlink $tmp or die "error: could not delete $tmp: $!";
-
-            # Refresh the handler.
-            delete $self->{handle};
-            $self->info("Rotated log files.");
-            1;
-        };
-
-        $rotation_error = $@;
-        $redis->del($lock_name);
-
+    # Based on Logfile::Rotate
+    # Rotate existing logs
+    for ( my $i = 7; $i > 1; $i-- ) {
+        my $j = $i - 1;
+        my $next = "$logpath.$i.gz";
+        my $prev = "$logpath.$j.gz";
+        if ( -r $prev && -f $prev ) {
+            rename( $prev, $next ) or die "error: rename failed: ($prev,$next)";
+        }
     }
 
-    $redis->quit();
-    die $rotation_error if $rotation_error;
+    # Move current logs to tempfile to stop new writes to it
+    my $tmp = "$logpath.rotate";
+    unlink $tmp if -e $tmp;
+    rename( $logpath, $tmp ) or die "error: could not detach $logpath to $tmp: $!";
 
+    # Gzip the detached tempfile
+    my $gz = gzopen( "$logpath.1.gz", "wb" ) or die "error: could not gzopen $logpath.1.gz: $!";
+    open( my $handle, '<', $tmp ) or die "Couldn't open $tmp: $!";
+    my $buffer;
+    $gz->gzwrite($buffer) while read( $handle, $buffer, 4096 ) > 0;
+    $gz->gzclose();
+    close $handle;
+    unlink $tmp or die "error: could not delete $tmp: $!";
 }
 
 1;

--- a/lib/LANraragi/Utils/RotatingLog.pm
+++ b/lib/LANraragi/Utils/RotatingLog.pm
@@ -70,7 +70,7 @@ sub append {
                 eval {
                     rotate( $path );
                     delete $self->{handle};
-                    $self->info("Rotated log files.");
+                    $self->handle;
                 };
                 $rotation_error = $@;
                 $redis->del($lock_name);
@@ -107,7 +107,7 @@ sub new {
         if ( $lock ) {
             eval {
                 LANraragi::Utils::RotatingLog::rotate( $path );
-                $self->info("Rotated log files.");
+                $self->handle;
                 1;
             };
 
@@ -136,7 +136,7 @@ sub new {
             # This happens during start of app (if no logfile exists).
             say "Creating logfile $logfile.";
             eval {
-                $self->info("Created logfile.");
+                $self->handle;
                 1;
             };
 

--- a/lib/LANraragi/Utils/RotatingLog.pm
+++ b/lib/LANraragi/Utils/RotatingLog.pm
@@ -1,0 +1,24 @@
+package LANraragi::Utils::RotatingLog;
+
+use strict;
+use warnings;
+use utf8;
+
+use POSIX;
+use Compress::Zlib;
+use Config;
+
+use Mojo::Base 'Mojo::Log';
+use Mojo::File;
+use LANraragi::Utils::Redis qw(redis_decode);
+use LANraragi::Model::Config;
+
+use constant IS_UNIX => ( $Config{osname} ne 'MSWin32' );
+
+BEGIN {
+    if ( !IS_UNIX ) {
+        require Win32API::File;
+    }
+}
+
+1;

--- a/lib/LANraragi/Utils/RotatingLog.pm
+++ b/lib/LANraragi/Utils/RotatingLog.pm
@@ -91,7 +91,7 @@ sub append {
 sub new {
     my $self = shift->SUPER::new(@_);
 
-    my $pgname  = $self->pgname // 'LANraragi';
+    my $pgname  = $self->pgname;
     my $devmode = $self->devmode;
     my $path    = $self->path;
     my $logfile = $self->logfile;
@@ -191,6 +191,24 @@ sub rotate {
     $gz->gzclose();
     close $handle;
     unlink $tmp or die "error: could not delete $tmp: $!";
+}
+
+# Refreshed cached handle.
+sub refresh_handle {
+    my $self = shift;
+
+    if ( IS_UNIX ) {
+        my $path            = $self->path;
+        my $cached_inode    = ( stat( $self->handle ) )[1];
+        my $path_inode      = ( stat( $path ) )[1];
+        if ( !defined $cached_inode || !defined $path_inode || $cached_inode != $path_inode ) {
+            open( my $fh, '>>', $path ) or die "Could not open logfile '$path': $!";
+            $self->handle($fh);
+        }
+    } else {
+        my $fh = get_win32_fh( $self->path );
+        $self->handle($fh);
+    }
 }
 
 1;

--- a/lib/LANraragi/Utils/RotatingLog.pm
+++ b/lib/LANraragi/Utils/RotatingLog.pm
@@ -28,8 +28,31 @@ BEGIN {
 
 has 'pgname';
 has 'devmode';
+has 'init_error';       # initialization error
+
 has maxrotationsize     => sub { 1048576 }; # 1 MiB
 has counter             => sub { 0 };
+
+# override: https://docs.mojolicious.org/Mojo/Log#handle
+has handle => sub {
+
+    # STDERR
+    return \*STDERR unless my $path = shift->path;
+
+    # File
+    if ( !IS_UNIX ) {
+        eval {
+            return get_win32_fh($path);
+        } or do {
+            my $error = $@;
+            shift->init_error($error);
+        }
+    }
+
+    # Fallback with default handle.
+    return Mojo::File->new($path)->open('>>');
+
+};
 
 # override: https://docs.mojolicious.org/Mojo/Log#append
 # include logic which checks every 1k lines whether to rotate logs.

--- a/lib/LANraragi/Utils/RotatingLog.pm
+++ b/lib/LANraragi/Utils/RotatingLog.pm
@@ -4,11 +4,13 @@ use strict;
 use warnings;
 use utf8;
 
+use Fcntl qw(:flock);
 use POSIX;
 use Compress::Zlib;
 use Config;
 
 use Mojo::Base 'Mojo::Log';
+use Mojo::Util      qw(encode);
 use Mojo::File;
 use LANraragi::Utils::Redis qw(redis_decode);
 use LANraragi::Model::Config;
@@ -23,7 +25,26 @@ BEGIN {
 
 has 'pgname';
 has 'devmode';
-has maxrotationsize => sub { 1048576 }; # 1 MiB
+has maxrotationsize     => sub { 1048576 }; # 1 MiB
+has counter             => sub { 0 };
+
+# override: https://docs.mojolicious.org/Mojo/Log#append
+# include logic which checks every 1k lines whether to rotate logs.
+sub append {
+    my ($self, $msg) = @_;
+
+    $self->counter( $self->counter+1 );
+
+    # every 1k lines, check size of path for log rotation
+    if ( $self->counter % 1000 == 0 ) {
+        return unless my $path = $self->path;
+        if ( -s $path > $self->maxrotationsize ) {
+            # TODO: do log rotation.
+        }
+    }
+
+    return $self->SUPER::append($msg);
+}
 
 # override: https://docs.mojolicious.org/Mojo/Log#new
 sub new {

--- a/lib/LANraragi/Utils/RotatingLog.pm
+++ b/lib/LANraragi/Utils/RotatingLog.pm
@@ -35,17 +35,20 @@ has counter             => sub { 0 };
 
 # override: https://docs.mojolicious.org/Mojo/Log#handle
 has handle => sub {
+    my $self = shift;
 
     # STDERR
-    return \*STDERR unless my $path = shift->path;
+    return \*STDERR unless my $path = $self->path;
 
     # File
     if ( !IS_UNIX ) {
-        eval {
-            return get_win32_fh($path);
-        } or do {
-            my $error = $@;
-            shift->init_error($error);
+        my $fh = eval {
+            get_win32_fh($path)
+        };
+        if ( my $error = $@ ) {
+            $self->init_error($error);
+        } else {
+            return $fh if $fh;
         }
     }
 

--- a/lib/LANraragi/Utils/RotatingLog.pm
+++ b/lib/LANraragi/Utils/RotatingLog.pm
@@ -128,13 +128,25 @@ sub new {
 }
 
 # Get perl file handler via Win32 native file handle of a logfile.
-# https://perldoc.perl.org/Win32API::File#createFile
+# https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilew
+# https://perldoc.perl.org/Win32API::File#CreateFile
 # https://perldoc.perl.org/Win32API::File#OsFHandleOpen
 sub get_win32_fh {
-    my $logfile = shift;
-    my $h = Win32API::File::createFile( $logfile, "rw", "rwd" ) or die "createFile failed for $logfile; win32 says: $^E; errno: $!";
+    my $sPath    = shift;
+    my $uAccess  = Win32API::File::FILE_APPEND_DATA();
+    my $uShare   = Win32API::File::FILE_SHARE_READ()
+        | Win32API::File::FILE_SHARE_WRITE()
+        | Win32API::File::FILE_SHARE_DELETE();
+    my $pSecAttr = [];
+    my $uCreate  = Win32API::File::OPEN_ALWAYS();
+    my $uFlags   = 0;
+    my $hModel   = [];
+    my $h = Win32API::File::CreateFile( $sPath, $uAccess, $uShare, $pSecAttr, $uCreate, $uFlags, $hModel )
+        or die "CreateFile failed for $sPath; win32 says: $^E; errno: $!";
+
     local *FH;
-    Win32API::File::OsFHandleOpen( *FH, $h, "a" ) or die "OsFHandleOpen failed for $logfile; $!";
+
+    Win32API::File::OsFHandleOpen( *FH, $h, "w" ) or die "OsFHandleOpen failed for $sPath; $!";
     binmode *FH, ':encoding(UTF-8)';
     return *FH;
 }

--- a/lib/LANraragi/Utils/RotatingLog.pm
+++ b/lib/LANraragi/Utils/RotatingLog.pm
@@ -26,7 +26,6 @@ BEGIN {
     }
 }
 
-has 'pgname';
 has 'logfile';
 
 has maxrotationsize     => sub { 1048576 }; # 1 MiB
@@ -90,7 +89,6 @@ sub append {
 sub new {
     my $self = shift->SUPER::new(@_);
 
-    my $pgname  = $self->pgname;
     my $path    = $self->path;
     my $logfile = $self->logfile;
 

--- a/lib/LANraragi/Utils/Routing.pm
+++ b/lib/LANraragi/Utils/Routing.pm
@@ -106,6 +106,7 @@ sub apply_routes {
 
     # log testing API
     $public_api->post('/api/logs/test')->to('api-other#test_logging');
+    $public_api->post('/api/logs/test_append')->to('api-other#test_append_logrotate');
 
     # OPDS API
     $public_api->get('/api/opds')->to('api-other#serve_opds_catalog');

--- a/lib/LANraragi/Utils/Routing.pm
+++ b/lib/LANraragi/Utils/Routing.pm
@@ -105,7 +105,7 @@ sub apply_routes {
     $logged_in->get('/duplicates')->to('duplicates#index');
 
     # log testing API
-    $public_api->get('/api/logs/test')->to('api-other#test_logging');
+    $public_api->post('/api/logs/test')->to('api-other#test_logging');
 
     # OPDS API
     $public_api->get('/api/opds')->to('api-other#serve_opds_catalog');

--- a/lib/LANraragi/Utils/Routing.pm
+++ b/lib/LANraragi/Utils/Routing.pm
@@ -104,6 +104,9 @@ sub apply_routes {
 
     $logged_in->get('/duplicates')->to('duplicates#index');
 
+    # log testing API
+    $public_api->get('/api/logs/test')->to('api-other#test_logging');
+
     # OPDS API
     $public_api->get('/api/opds')->to('api-other#serve_opds_catalog');
     $public_api->get('/api/opds/:id')->to('api-other#serve_opds_item');

--- a/lib/LANraragi/Utils/Routing.pm
+++ b/lib/LANraragi/Utils/Routing.pm
@@ -105,8 +105,7 @@ sub apply_routes {
     $logged_in->get('/duplicates')->to('duplicates#index');
 
     # log testing API
-    $public_api->post('/api/logs/test')->to('api-other#test_logging');
-    $public_api->post('/api/logs/test_append')->to('api-other#test_append_logrotate');
+    $public_api->post('/api/logs/test')->to('api-other#log_messages_test');
 
     # OPDS API
     $public_api->get('/api/opds')->to('api-other#serve_opds_catalog');

--- a/tools/install.pl
+++ b/tools/install.pl
@@ -162,6 +162,7 @@ if ( $back || $full ) {
         install_package( "Win32::Process", $cpanopt );
         install_package( "Win32::FileSystemHelper", "https://github.com/Guerra24/Win32-FileSystemHelper/archive/d2f241714111ff4ab77498a15839315dd28b6287.zip " . $cpanopt );
         install_package( "File::ChangeNotify::Watcher::Win32", "https://github.com/Guerra24/File-ChangeNotify-Watcher-Win32/archive/7cb4e60823569cca8e7652d19b1ba5b5cac00a16.zip " .$cpanopt );
+        install_package( "Win32API::File", $cpanopt );
     }
 
     if ( system( "cpanm --installdeps ./tools/. --notest" . $cpanopt ) != 0 ) {


### PR DESCRIPTION
Prevent race conditions and truncate issues with win32api library, doing away with the necessity for copytruncate data durability limitations.

Slowly and steadily move Logging.pm logic over to RotatingLog.pm