### PR TITLE
Rotating Mojo Log implementation

### DIFF
--- a/lib/LANraragi/Utils/Logging.pm
+++ b/lib/LANraragi/Utils/Logging.pm
@@ -31,18 +31,6 @@ BEGIN {
 
 our %LOGGER_CACHE;
 
-# Get perl file handler via Win32 native file handle of a logfile.
-# https://perldoc.perl.org/Win32API::File#createFile
-# https://perldoc.perl.org/Win32API::File#OsFHandleOpen
-sub _get_win32_fh {
-    my $logfile = shift;
-    my $h = Win32API::File::createFile( $logfile, "rw", "rwd" ) or die "createFile failed for $logfile; win32 says: $^E; errno: $!";
-    local *FH;
-    Win32API::File::OsFHandleOpen( *FH, $h, "a" ) or die "OsFHandleOpen failed for $logfile; $!";
-    binmode *FH, ':encoding(UTF-8)';
-    return *FH;
-}
-
 # Ensure logfile created, and the mojo logger cached and returned, or die trying.
 sub _ensure_logger {
     my $logpath     = $_[0];
@@ -63,7 +51,7 @@ sub _ensure_logger {
         } else {
             # get windows logger and fallback to generic logger
             eval {
-                my $fh = _get_win32_fh( $logpath );
+                my $fh = LANraragi::Utils::RotatingLog::get_win32_fh( $logpath );
                 $log = LANraragi::Utils::RotatingLog->new(
                     level => 'info'
                 );
@@ -126,7 +114,7 @@ sub get_logger {
                     $log->handle($fh);
                 }
             } else {
-                my $fh = _get_win32_fh( $logpath );
+                my $fh = LANraragi::Utils::RotatingLog::get_win32_fh( $logpath );
                 $log->handle($fh);
             }
             1;

--- a/lib/LANraragi/Utils/Logging.pm
+++ b/lib/LANraragi/Utils/Logging.pm
@@ -48,14 +48,16 @@ sub _ensure_logger {
     my $logpath     = $_[0];
     my $operation   = $_[1];
     my $cache_key   = $_[2];
+    my $pgname      = $_[3];
+    my $devmode     = $_[4];
     my $log;
 
     eval {
         if ( IS_UNIX ) {
             open( my $fh, '>>', $logpath ) or die "Could not create logfile '$logpath': $!";
             $log = LANraragi::Utils::RotatingLog->new(
-                path  => $logpath,
-                level => 'info'
+                path    => $logpath,
+                level   => 'info',
             );
             $log->handle;
         } else {
@@ -133,6 +135,8 @@ sub get_logger {
         return $log;
     }
 
+    my $devmode = LANraragi::Model::Config->enable_devmode;
+
     # Logfile lock owners have exclusive ability to create a logfile.
     # Non-owners may only append or wait for logfile availability.
     my $lock_name   = "log-rotate:$logfile";
@@ -173,7 +177,7 @@ sub get_logger {
                 $gz->gzclose();
                 close $handle;
                 unlink $tmp or die "error: could not delete $tmp: $!";
-                $log = _ensure_logger( $logpath, "rotation" , $cache_key );
+                $log = _ensure_logger( $logpath, "rotation" , $cache_key, $pgname, $devmode );
                 $log->info("Rotated log files.");
                 1;
             };
@@ -203,7 +207,7 @@ sub get_logger {
             # This happens during start of app (if no logfile exists).
             say "Creating logfile $logfile.";
             eval {
-                $log = _ensure_logger( $logpath, "create", $cache_key );
+                $log = _ensure_logger( $logpath, "create", $cache_key, $pgname, $devmode );
                 $log->info("Created logfile.");
                 1;
             };
@@ -220,7 +224,7 @@ sub get_logger {
                     $tries++;
                 } else {
                     eval {
-                        $log = _ensure_logger( $logpath, "wait", $cache_key );
+                        $log = _ensure_logger( $logpath, "wait", $cache_key, $pgname, $devmode );
                         1;
                     };
                     $logfile_create_error   = $@;
@@ -238,53 +242,13 @@ sub get_logger {
 
     } else {
         eval {
-            $log = _ensure_logger( $logpath, "default", $cache_key );
+            $log = _ensure_logger( $logpath, "default", $cache_key, $pgname, $devmode );
             1;
         };
 
         my $logfile_exist_error = $@;
         die $logfile_exist_error if $logfile_exist_error;
     }
-
-    my $devmode = LANraragi::Model::Config->enable_devmode;
-
-    #Tell logger to store debug logs as well in debug mode
-    if ($devmode) {
-        $log->level('debug');
-    }
-
-    # Step down into trace if we're launched from npm run dev-server-verbose
-    if ( $ENV{LRR_DEVSERVER} ) {
-        $log->level('trace');
-    }
-
-    #Copy logged messages to STDOUT with the matching name
-    $log->on(
-        message => sub {
-            my ( $time, $level, @lines ) = @_;
-
-            #Like with logging to file, debug logs are only printed in debug mode
-            unless ( $devmode == 0 && ( $level eq 'debug' || $level eq 'trace' ) ) {
-                print "[$pgname] [$level] ";
-                say $lines[0];
-            }
-        }
-    );
-
-    $log->format(
-        sub {
-            my ( $time, $level, @lines ) = @_;
-            my $time2 = strftime( "%Y-%m-%d %H:%M:%S", localtime($time) );
-
-            my $logstring = join( "\n", @lines );
-
-            # We'd like to make sure we always show proper UTF-8.
-            # redis_decode, while not initially designed for this, does the job.
-            $logstring = redis_decode($logstring);
-
-            return "[$time2] [$pgname] [$level] $logstring\n";
-        }
-    );
 
     return $log;
 }

--- a/lib/LANraragi/Utils/Logging.pm
+++ b/lib/LANraragi/Utils/Logging.pm
@@ -52,23 +52,11 @@ sub _ensure_logger {
     };
 
     if ( my $error = $@ ) {
-        my $msg = "Logger initialization failed during $operation: $error";
-        eval {
-            my $timestamp = strftime( "%Y-%m-%d %H:%M:%S", localtime(time) );
-            my $formatted = "[$timestamp] [$pgname] [error] Fatal error while initializing logger ($operation): $error\n";
-            if ( open my $fh, '>>', $logpath ) {
-                print $fh $formatted;
-                close $fh;
-            } else {
-                warn "Could not write to logfile $logpath: $!";
-            }
-        };
-        die $msg;
-    }
-
-    # Raise an error if log initialization failed (but is still able to emit files).
-    if ( my $init_error = $log->init_error ) {
-        $log->error("Failed to initialize logger: $init_error ");
+        $log = Mojo::Log->new(
+            path    => $logpath,
+            level   => 'info',
+        );
+        $log->error("RotatingLog initialization failed, falling back to Mojo::Log ($operation): $error");
     }
 
     $LOGGER_CACHE{$cache_key} = $log;

--- a/lib/LANraragi/Utils/Logging.pm
+++ b/lib/LANraragi/Utils/Logging.pm
@@ -49,16 +49,27 @@ sub _ensure_logger {
         1;
     };
 
-    my $error = $@;
-    die $error if $error;
-
-    $LOGGER_CACHE{$cache_key} = $log;
+    if ( my $error = $@ ) {
+        my $msg = "Logger initialization failed during $operation: $error";
+        eval {
+            my $timestamp = strftime( "%Y-%m-%d %H:%M:%S", localtime(time) );
+            my $formatted = "[$timestamp] [$pgname] [error] Fatal error while initializing logger ($operation): $error\n";
+            if ( open my $fh, '>>', $logpath ) {
+                print $fh $formatted;
+                close $fh;
+            } else {
+                warn "Could not write to logfile $logpath: $!";
+            }
+        };
+        die $msg;
+    }
 
     # Raise an error if log initialization failed (but is still able to emit files).
     if ( my $init_error = $log->init_error ) {
         $log->error("Failed to initialize logger: $init_error ");
     }
 
+    $LOGGER_CACHE{$cache_key} = $log;
     return $log;
 }
 

--- a/lib/LANraragi/Utils/Logging.pm
+++ b/lib/LANraragi/Utils/Logging.pm
@@ -34,15 +34,17 @@ our %LOGGER_CACHE;
 # Ensure logfile created, and the mojo logger cached and returned, or die trying.
 sub _ensure_logger {
     my $logpath     = $_[0];
-    my $operation   = $_[1];
-    my $cache_key   = $_[2];
-    my $pgname      = $_[3];
-    my $devmode     = $_[4];
+    my $logfile     = $_[1];
+    my $operation   = $_[2];
+    my $cache_key   = $_[3];
+    my $pgname      = $_[4];
+    my $devmode     = $_[5];
     my $log;
 
     eval {
         $log = LANraragi::Utils::RotatingLog->new(
             path    => $logpath,
+            logfile => $logfile,
             level   => 'info',
         );
         $log->handle;
@@ -161,7 +163,7 @@ sub get_logger {
                 $gz->gzclose();
                 close $handle;
                 unlink $tmp or die "error: could not delete $tmp: $!";
-                $log = _ensure_logger( $logpath, "rotation" , $cache_key, $pgname, $devmode );
+                $log = _ensure_logger( $logpath, $logfile, "rotation" , $cache_key, $pgname, $devmode );
                 $log->info("Rotated log files.");
                 1;
             };
@@ -191,7 +193,7 @@ sub get_logger {
             # This happens during start of app (if no logfile exists).
             say "Creating logfile $logfile.";
             eval {
-                $log = _ensure_logger( $logpath, "create", $cache_key, $pgname, $devmode );
+                $log = _ensure_logger( $logpath, $logfile, "create", $cache_key, $pgname, $devmode );
                 $log->info("Created logfile.");
                 1;
             };
@@ -208,7 +210,7 @@ sub get_logger {
                     $tries++;
                 } else {
                     eval {
-                        $log = _ensure_logger( $logpath, "wait", $cache_key, $pgname, $devmode );
+                        $log = _ensure_logger( $logpath, $logfile, "wait", $cache_key, $pgname, $devmode );
                         1;
                     };
                     $logfile_create_error   = $@;
@@ -226,7 +228,7 @@ sub get_logger {
 
     } else {
         eval {
-            $log = _ensure_logger( $logpath, "default", $cache_key, $pgname, $devmode );
+            $log = _ensure_logger( $logpath, $logfile, "default", $cache_key, $pgname, $devmode );
             1;
         };
 

--- a/lib/LANraragi/Utils/Logging.pm
+++ b/lib/LANraragi/Utils/Logging.pm
@@ -41,32 +41,11 @@ sub _ensure_logger {
     my $log;
 
     eval {
-        if ( IS_UNIX ) {
-            open( my $fh, '>>', $logpath ) or die "Could not create logfile '$logpath': $!";
-            $log = LANraragi::Utils::RotatingLog->new(
-                path    => $logpath,
-                level   => 'info',
-            );
-            $log->handle;
-        } else {
-            # get windows logger and fallback to generic logger
-            eval {
-                my $fh = LANraragi::Utils::RotatingLog::get_win32_fh( $logpath );
-                $log = LANraragi::Utils::RotatingLog->new(
-                    level => 'info'
-                );
-                $log->handle( $fh );
-                1;
-            } or do {
-                my $error = $@;
-                $log = LANraragi::Utils::RotatingLog->new(
-                    path    => $logpath,
-                    level   => 'info'
-                );
-                $log->handle;
-                $log->error("Failed to create logger from win32API handle: $@");
-            };
-        }
+        $log = LANraragi::Utils::RotatingLog->new(
+            path    => $logpath,
+            level   => 'info',
+        );
+        $log->handle;
         1;
     };
 
@@ -74,6 +53,12 @@ sub _ensure_logger {
     die $error if $error;
 
     $LOGGER_CACHE{$cache_key} = $log;
+
+    # Raise an error if log initialization failed (but is still able to emit files).
+    if ( my $init_error = $log->init_error ) {
+        $log->error("Failed to initialize logger: $init_error ");
+    }
+
     return $log;
 }
 

--- a/lib/LANraragi/Utils/Logging.pm
+++ b/lib/LANraragi/Utils/Logging.pm
@@ -53,7 +53,7 @@ sub _ensure_logger {
     eval {
         if ( IS_UNIX ) {
             open( my $fh, '>>', $logpath ) or die "Could not create logfile '$logpath': $!";
-            $log = Mojo::Log->new(
+            $log = LANraragi::Utils::RotatingLog->new(
                 path  => $logpath,
                 level => 'info'
             );
@@ -62,14 +62,14 @@ sub _ensure_logger {
             # get windows logger and fallback to generic logger
             eval {
                 my $fh = _get_win32_fh( $logpath );
-                $log = Mojo::Log->new(
+                $log = LANraragi::Utils::RotatingLog->new(
                     level => 'info'
                 );
                 $log->handle( $fh );
                 1;
             } or do {
                 my $error = $@;
-                $log = Mojo::Log->new(
+                $log = LANraragi::Utils::RotatingLog->new(
                     path    => $logpath,
                     level   => 'info'
                 );

--- a/lib/LANraragi/Utils/Logging.pm
+++ b/lib/LANraragi/Utils/Logging.pm
@@ -14,6 +14,7 @@ use Encode;
 use File::ReadBackwards;
 use Compress::Zlib;
 use LANraragi::Model::Config;
+use LANraragi::Utils::RotatingLog;
 use LANraragi::Utils::Redis qw(redis_decode);
 
 use constant IS_UNIX => ( $Config{osname} ne 'MSWin32' );

--- a/lib/LANraragi/Utils/RotatingLog.pm
+++ b/lib/LANraragi/Utils/RotatingLog.pm
@@ -21,4 +21,57 @@ BEGIN {
     }
 }
 
+has 'pgname';
+has 'devmode';
+has maxrotationsize => sub { 1048576 }; # 1 MiB
+
+# override: https://docs.mojolicious.org/Mojo/Log#new
+sub new {
+    my $self = shift->SUPER::new(@_);
+
+    my $pgname  = $self->pgname // 'LANraragi';
+    my $devmode = $self->devmode ? 1 : 0;
+    my $path    = $self->path;
+
+    #Tell logger to store debug logs as well in debug mode
+    if ($devmode) {
+        $self->level('debug');
+    }
+
+    # Step down into trace if we're launched from npm run dev-server-verbose
+    if ( $ENV{LRR_DEVSERVER} ) {
+        $self->level('trace');
+    }
+
+    # Copy logged messages to STDOUT with the matching name
+    $self->on(
+        message => sub {
+            my ( $log, $level, @lines ) = @_;
+
+            # Like with logging to file, debug logs are only printed in debug mode
+            unless ( $devmode == 0 && ( $level eq 'debug' || $level eq 'trace' ) ) {
+                print "[$pgname] [$level] ";
+                say $lines[0];
+            }
+        }
+    );
+
+    $self->format(
+        sub {
+            my ( $time, $level, @lines ) = @_;
+            my $time2 = strftime( "%Y-%m-%d %H:%M:%S", localtime($time) );
+
+            my $logstring = join( "\n", @lines );
+
+            # We'd like to make sure we always show proper UTF-8.
+            # redis_decode, while not initially designed for this, does the job.
+            $logstring = redis_decode($logstring);
+
+            return "[$time2] [$pgname] [$level] $logstring\n";
+        }
+    );
+
+    return $self;
+}
+
 1;

--- a/lib/LANraragi/Utils/RotatingLog.pm
+++ b/lib/LANraragi/Utils/RotatingLog.pm
@@ -15,6 +15,9 @@ use Mojo::File;
 use LANraragi::Utils::Redis qw(redis_decode);
 use LANraragi::Model::Config;
 
+use Exporter 'import';
+our @EXPORT_OK = qw(get_win32_fh);
+
 use constant IS_UNIX => ( $Config{osname} ne 'MSWin32' );
 
 BEGIN {
@@ -93,6 +96,18 @@ sub new {
     );
 
     return $self;
+}
+
+# Get perl file handler via Win32 native file handle of a logfile.
+# https://perldoc.perl.org/Win32API::File#createFile
+# https://perldoc.perl.org/Win32API::File#OsFHandleOpen
+sub get_win32_fh {
+    my $logfile = shift;
+    my $h = Win32API::File::createFile( $logfile, "rw", "rwd" ) or die "createFile failed for $logfile; win32 says: $^E; errno: $!";
+    local *FH;
+    Win32API::File::OsFHandleOpen( *FH, $h, "a" ) or die "OsFHandleOpen failed for $logfile; $!";
+    binmode *FH, ':encoding(UTF-8)';
+    return *FH;
 }
 
 1;

--- a/lib/LANraragi/Utils/RotatingLog.pm
+++ b/lib/LANraragi/Utils/RotatingLog.pm
@@ -27,9 +27,10 @@ BEGIN {
 }
 
 has 'pgname';
-has 'devmode';
+has 'logfile';
 has 'init_error';       # initialization error
 
+has devmode             => sub { LANraragi::Model::Config->enable_devmode };
 has maxrotationsize     => sub { 1048576 }; # 1 MiB
 has counter             => sub { 0 };
 
@@ -67,8 +68,9 @@ sub append {
     # every 1k lines, check size of path for log rotation
     if ( $self->counter % 1000 == 0 ) {
         return unless my $path = $self->path;
-        if ( -s $path > $self->maxrotationsize ) {
-            # TODO: do log rotation.
+        if ( -s $path > $self->maxrotationsize && (my $logfile = $self->logfile) ) {
+            my $lock_name = "log-rotate:$logfile";
+            rotate( $self, $lock_name, "rotation" );
         }
     }
 
@@ -80,8 +82,9 @@ sub new {
     my $self = shift->SUPER::new(@_);
 
     my $pgname  = $self->pgname // 'LANraragi';
-    my $devmode = $self->devmode ? 1 : 0;
+    my $devmode = $self->devmode;
     my $path    = $self->path;
+    my $logfile = $self->logfile;
 
     #Tell logger to store debug logs as well in debug mode
     if ($devmode) {
@@ -134,6 +137,63 @@ sub get_win32_fh {
     Win32API::File::OsFHandleOpen( *FH, $h, "a" ) or die "OsFHandleOpen failed for $logfile; $!";
     binmode *FH, ':encoding(UTF-8)';
     return *FH;
+}
+
+# Do log rotation.
+sub rotate {
+    my $self        = shift;
+    my $lock_name   = shift;
+    my $operation   = shift;
+
+    # Rotate log if it's > 1MB
+    my $redis       = LANraragi::Model::Config->get_redis_config;
+    my $lock           = $redis->set( $lock_name, 1, 'NX', 'EX', 10 );
+    my $rotation_error;
+
+    if ( $lock ) {
+        my $logpath = $self->path;
+        eval {
+            say "Rotating logpath $logpath";
+
+            # Based on Logfile::Rotate
+            # Rotate existing logs
+            for ( my $i = 7; $i > 1; $i-- ) {
+                my $j = $i - 1;
+                my $next = "$logpath.$i.gz";
+                my $prev = "$logpath.$j.gz";
+                if ( -r $prev && -f $prev ) {
+                    rename( $prev, $next ) or die "error: rename failed: ($prev,$next)";
+                }
+            }
+
+            # Move current logs to tempfile to stop new writes to it
+            my $tmp = "$logpath.rotate";
+            unlink $tmp if -e $tmp;
+            rename( $logpath, $tmp ) or die "error: could not detach $logpath to $tmp: $!";
+
+            # Gzip the detached tempfile
+            my $gz = gzopen( "$logpath.1.gz", "wb" ) or die "error: could not gzopen $logpath.1.gz: $!";
+            open( my $handle, '<', $tmp ) or die "Couldn't open $tmp: $!";
+            my $buffer;
+            $gz->gzwrite($buffer) while read( $handle, $buffer, 4096 ) > 0;
+            $gz->gzclose();
+            close $handle;
+            unlink $tmp or die "error: could not delete $tmp: $!";
+
+            # Invalidate the handler.
+            $self->handle(undef);
+            $self->info("Rotated log files.");
+            1;
+        };
+
+        $rotation_error = $@;
+        $redis->del($lock_name);
+
+    }
+
+    $redis->quit();
+    die $rotation_error if $rotation_error;
+
 }
 
 1;

--- a/lib/LANraragi/Utils/RotatingLog.pm
+++ b/lib/LANraragi/Utils/RotatingLog.pm
@@ -28,7 +28,6 @@ BEGIN {
 
 has 'pgname';
 has 'logfile';
-has 'init_error';       # initialization error
 
 has devmode             => sub { LANraragi::Model::Config->enable_devmode };
 has maxrotationsize     => sub { 1048576 }; # 1 MiB
@@ -43,14 +42,8 @@ has handle => sub {
 
     # File
     if ( !IS_UNIX ) {
-        my $fh = eval {
-            get_win32_fh($path)
-        };
-        if ( my $error = $@ ) {
-            $self->init_error($error);
-        } else {
-            return $fh if $fh;
-        }
+        my $fh = get_win32_fh($path);
+        return $fh if $fh;
     }
 
     # Fallback with default handle.

--- a/lib/LANraragi/Utils/RotatingLog.pm
+++ b/lib/LANraragi/Utils/RotatingLog.pm
@@ -1,0 +1,24 @@
+package LANraragi::Utils::RotatingLog;
+
+use strict;
+use warnings;
+use utf8;
+
+use POSIX;
+use Compress::Zlib;
+use Config;
+
+use Mojo::Base 'Mojo::Log';
+use Mojo::File;
+use LANraragi::Utils::Redis qw(redis_decode);
+use LANraragi::Model::Config;
+
+use constant IS_UNIX => ( $Config{osname} ne 'MSWin32' );
+
+BEGIN {
+    if ( !IS_UNIX ) {
+        require Win32API::File;
+    }
+}
+
+1;

--- a/lib/LANraragi/Utils/RotatingLog.pm
+++ b/lib/LANraragi/Utils/RotatingLog.pm
@@ -28,8 +28,31 @@ BEGIN {
 
 has 'pgname';
 has 'devmode';
+has 'init_error';       # initialization error
+
 has maxrotationsize     => sub { 1048576 }; # 1 MiB
 has counter             => sub { 0 };
+
+# override: https://docs.mojolicious.org/Mojo/Log#handle
+has handle => sub {
+
+    # STDERR
+    return \*STDERR unless my $path = shift->path;
+
+    # File
+    if ( !IS_UNIX ) {
+        eval {
+            return get_win32_fh($path);
+        } or do {
+            my $error = $@;
+            shift->init_error($error);
+        }
+    }
+
+    # Fallback with default handle.
+    return Mojo::File->new($path)->open('>>');
+
+};
 
 # override: https://docs.mojolicious.org/Mojo/Log#append
 # include logic which checks every 1k lines whether to rotate logs.

--- a/lib/LANraragi/Utils/RotatingLog.pm
+++ b/lib/LANraragi/Utils/RotatingLog.pm
@@ -4,11 +4,13 @@ use strict;
 use warnings;
 use utf8;
 
+use Fcntl qw(:flock);
 use POSIX;
 use Compress::Zlib;
 use Config;
 
 use Mojo::Base 'Mojo::Log';
+use Mojo::Util      qw(encode);
 use Mojo::File;
 use LANraragi::Utils::Redis qw(redis_decode);
 use LANraragi::Model::Config;
@@ -23,7 +25,26 @@ BEGIN {
 
 has 'pgname';
 has 'devmode';
-has maxrotationsize => sub { 1048576 }; # 1 MiB
+has maxrotationsize     => sub { 1048576 }; # 1 MiB
+has counter             => sub { 0 };
+
+# override: https://docs.mojolicious.org/Mojo/Log#append
+# include logic which checks every 1k lines whether to rotate logs.
+sub append {
+    my ($self, $msg) = @_;
+
+    $self->counter( $self->counter+1 );
+
+    # every 1k lines, check size of path for log rotation
+    if ( $self->counter % 1000 == 0 ) {
+        return unless my $path = $self->path;
+        if ( -s $path > $self->maxrotationsize ) {
+            # TODO: do log rotation.
+        }
+    }
+
+    return $self->SUPER::append($msg);
+}
 
 # override: https://docs.mojolicious.org/Mojo/Log#new
 sub new {

--- a/lib/LANraragi/Utils/RotatingLog.pm
+++ b/lib/LANraragi/Utils/RotatingLog.pm
@@ -35,17 +35,20 @@ has counter             => sub { 0 };
 
 # override: https://docs.mojolicious.org/Mojo/Log#handle
 has handle => sub {
+    my $self = shift;
 
     # STDERR
-    return \*STDERR unless my $path = shift->path;
+    return \*STDERR unless my $path = $self->path;
 
     # File
     if ( !IS_UNIX ) {
-        eval {
-            return get_win32_fh($path);
-        } or do {
-            my $error = $@;
-            shift->init_error($error);
+        my $fh = eval {
+            get_win32_fh($path)
+        };
+        if ( my $error = $@ ) {
+            $self->init_error($error);
+        } else {
+            return $fh if $fh;
         }
     }
 

--- a/lib/LANraragi/Utils/RotatingLog.pm
+++ b/lib/LANraragi/Utils/RotatingLog.pm
@@ -128,13 +128,25 @@ sub new {
 }
 
 # Get perl file handler via Win32 native file handle of a logfile.
-# https://perldoc.perl.org/Win32API::File#createFile
+# https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilew
+# https://perldoc.perl.org/Win32API::File#CreateFile
 # https://perldoc.perl.org/Win32API::File#OsFHandleOpen
 sub get_win32_fh {
-    my $logfile = shift;
-    my $h = Win32API::File::createFile( $logfile, "rw", "rwd" ) or die "createFile failed for $logfile; win32 says: $^E; errno: $!";
+    my $sPath    = shift;
+    my $uAccess  = Win32API::File::FILE_APPEND_DATA();
+    my $uShare   = Win32API::File::FILE_SHARE_READ()
+        | Win32API::File::FILE_SHARE_WRITE()
+        | Win32API::File::FILE_SHARE_DELETE();
+    my $pSecAttr = [];
+    my $uCreate  = Win32API::File::OPEN_ALWAYS();
+    my $uFlags   = 0;
+    my $hModel   = [];
+    my $h = Win32API::File::CreateFile( $sPath, $uAccess, $uShare, $pSecAttr, $uCreate, $uFlags, $hModel )
+        or die "CreateFile failed for $sPath; win32 says: $^E; errno: $!";
+
     local *FH;
-    Win32API::File::OsFHandleOpen( *FH, $h, "a" ) or die "OsFHandleOpen failed for $logfile; $!";
+
+    Win32API::File::OsFHandleOpen( *FH, $h, "w" ) or die "OsFHandleOpen failed for $sPath; $!";
     binmode *FH, ':encoding(UTF-8)';
     return *FH;
 }


### PR DESCRIPTION
keep log rotate times around ~32s.

Why? For long-running tasks a single logger is used, and this logger as is ignores the state of the underling file it's writing to, even if it's long gone.