### PR TITLE
Pass long-running append tests

### DIFF
--- a/lib/LANraragi/Controller/Api/Other.pm
+++ b/lib/LANraragi/Controller/Api/Other.pm
@@ -6,6 +6,7 @@ use Redis;
 
 use LANraragi::Model::Stats;
 use LANraragi::Model::Opds;
+use LANraragi::Utils::Logging    qw(get_logger);
 use LANraragi::Utils::Generic    qw(render_api_response);
 use LANraragi::Utils::Plugins    qw(get_plugin get_plugins use_plugin);
 
@@ -41,6 +42,26 @@ sub serve_serverinfo {
             cache_last_cleared     => $last_clear
         }
     );
+}
+
+sub log_messages_test {
+
+    my $self        = shift;
+    my $data        = $self->req->json;
+    my $messages    = $data->{messages};
+    my $logger      = get_logger( "LANraragi", "lanraragi" ); # second arg MUST be "lanraragi".
+
+    foreach my $message ( @$messages ) {
+        $logger->info($message);
+    }
+
+    $self->render(
+        json => {
+            operation   => "log_messages_test",
+            success     => 1
+        }
+    );
+
 }
 
 # Basic OPDS catalog
@@ -186,4 +207,3 @@ sub use_plugin_async {
 }
 
 1;
-

--- a/lib/LANraragi/Utils/Routing.pm
+++ b/lib/LANraragi/Utils/Routing.pm
@@ -104,6 +104,9 @@ sub apply_routes {
 
     $logged_in->get('/duplicates')->to('duplicates#index');
 
+    # log testing API
+    $public_api->post('/api/logs/test')->to('api-other#log_messages_test');
+
     # OPDS API
     $public_api->get('/api/opds')->to('api-other#serve_opds_catalog');
     $public_api->get('/api/opds/:id')->to('api-other#serve_opds_item');


### PR DESCRIPTION
Current RotatingLog's append behavior is not enough to guard against lost logs from concurrent long-running loggers.