### PR TITLE
replace getImgSizeAsync with performance.getEntriesByName

### DIFF
--- a/public/js/reader.js
+++ b/public/js/reader.js
@@ -898,12 +898,12 @@ Reader.loadImage = function (index) {
         const img = new Image();
         img.src = src;
         Reader.preloadedImg[src] = img;
-        if (!Reader.preloadedSizes[index]) {
-            LRR.getImgSizeAsync(src).done((data, textStatus, request) => {
-                const size = parseInt(request.getResponseHeader("Content-Length") / 1024, 10);
-                Reader.preloadedSizes[index] = size;
-            });
-        }
+        img.addEventListener("load", () => {
+            const entry = performance.getEntriesByName(img.src, "resource").pop();
+            if (entry) {
+                Reader.preloadedSizes[index] = Math.round(entry.decodedBodySize / 1024);
+            }
+        });
     }
 
     return Reader.preloadedImg[src];


### PR DESCRIPTION
basically, we've narrowed down the root cause to concurrent XHR poisoning fetch deduplication by `getImgSizeAsync`. This is only demonstrated via observing live testing, but I have no idea why.